### PR TITLE
Bugfix: stats for cached responses with error_page directive do not create a cache file

### DIFF
--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -802,7 +802,7 @@ ngx_http_vhost_traffic_status_shm_add_cache(ngx_http_request_t *r,
 
     u = r->upstream;
 
-    if (u != NULL && u->cache_status != 0) {
+    if (u != NULL && u->cache_status != 0 && r->cache != NULL) {
         c = r->cache;
         cache = c->file_cache;
     } else {


### PR DESCRIPTION
When a request fail and have an error_page configured for it the vts module will not have access to r->cache because a cache file isn't created.
The problem can be easily reproduced with any request to a nginx with the bellow configuration.

```
pid         logs/nginx.pid;
error_log   logs/nginx-main_error.log debug;

worker_processes    2;

events {
  worker_connections  1024;
  use                 epoll; # Linux
}

http {
  default_type    text/plain;

  vhost_traffic_status_zone;

  types {
      text/html   html;
  }

  log_format main  '[$time_local] $host "$request" $request_time s '
                   '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
                   'cache_status: "$upstream_cache_status" args: "$args '
                   'sorted_args: "$sorted_querystring_args" ';

  access_log       logs/nginx-http_access.log;

  proxy_cache_path /tmp/cache levels=1:2 keys_zone=zone:10m inactive=10d max_size=100m;

  error_page   404     /error_pages;
  error_page   502 503 504  /error_pages;

  server {
    listen          8080;

    access_log       logs/nginx-http_access.log main;

    location /status {
      vhost_traffic_status_display;
      vhost_traffic_status_display_format json;
    }

    location /error_pages {
      return 200 "Some ERROR happened\n";
    }

    location / {
      proxy_pass http://localhost:8081;

      proxy_cache zone;
      proxy_cache_key "$request_uri";
      proxy_cache_valid 200 10m;
      proxy_cache_valid any 2m;
    }
  }
}
```