### PR TITLE
fix: nginx will crash at vts module when configure file has no http b…

### DIFF
--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -899,6 +899,13 @@ ngx_http_vhost_traffic_status_init_worker(ngx_cycle_t *cycle)
                    "http vts init worker");
 
     ctx = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_vhost_traffic_status_module);
+
+    if(!ctx){
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
+                       "vts::init_worker(): is bypassed due to no http block in configure file");
+        return NGX_OK;
+    }
+
     if (!(ctx->enable & ctx->dump) || ctx->rbtree == NULL) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
                        "vts::init_worker(): is bypassed");
@@ -929,6 +936,13 @@ ngx_http_vhost_traffic_status_exit_worker(ngx_cycle_t *cycle)
                    "http vts exit worker");
 
     ctx = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_vhost_traffic_status_module);
+
+    if(!ctx){
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
+                       "vts::exit_worker(): is bypassed due to no http block in configure file");
+        return;
+    }
+
     if (!(ctx->enable & ctx->dump) || ctx->rbtree == NULL) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cycle->log, 0,
                        "vts::exit_worker(): is bypassed");


### PR DESCRIPTION
Nginx will crash at vts module when configure file(e.g. nginx.conf) has no http block, this is because ngx_http_cycle_get_module_main_conf will return NULL in this situation.