### PR TITLE
Improve Prometheus metrics

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -36,7 +36,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set_main(ngx_http_request_t *r,
 
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN, &ngx_cycle->hostname,
                       NGINX_VERSION,
-                      (double) (ngx_http_vhost_traffic_status_current_msec() - vtscf->start_msec) / 1000,
+                      (double) vtscf->start_msec / 1000,
                       ac, rd, wr, wa, ap, hn, rq,
                       shm_info->name, shm_info->max_size,
                       shm_info->used_size, shm_info->used_node);

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -69,10 +69,10 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server_node(
                       &server, vtsn->stat_4xx_counter,
                       &server, vtsn->stat_5xx_counter,
                       &server, vtsn->stat_request_counter,
-                      &server, vtsn->stat_request_time_counter,
-                      &server, ngx_http_vhost_traffic_status_node_time_queue_average(
+                      &server, (double) vtsn->stat_request_time_counter / 1000,
+                      &server, (double) ngx_http_vhost_traffic_status_node_time_queue_average(
                                    &vtsn->stat_request_times, vtscf->average_method,
-                                   vtscf->average_period));
+                                   vtscf->average_period) / 1000);
 
 #if (NGX_HTTP_CACHE)
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE,
@@ -179,11 +179,11 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(
                       &filter, &filter_name, vtsn->stat_4xx_counter,
                       &filter, &filter_name, vtsn->stat_5xx_counter,
                       &filter, &filter_name, vtsn->stat_request_counter,
-                      &filter, &filter_name, vtsn->stat_request_time_counter,
+                      &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000,
                       &filter, &filter_name,
-                      ngx_http_vhost_traffic_status_node_time_queue_average(
+                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
                           &vtsn->stat_request_times, vtscf->average_method,
-                          vtscf->average_period));
+                          vtscf->average_period) / 1000);
 
 #if (NGX_HTTP_CACHE)
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE,
@@ -260,16 +260,16 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
                       &upstream, &upstream_server, vtsn->stat_4xx_counter,
                       &upstream, &upstream_server, vtsn->stat_5xx_counter,
                       &upstream, &upstream_server, vtsn->stat_request_counter,
-                      &upstream, &upstream_server, vtsn->stat_request_time_counter,
+                      &upstream, &upstream_server, (double) vtsn->stat_request_time_counter / 1000,
                       &upstream, &upstream_server,
-                      ngx_http_vhost_traffic_status_node_time_queue_average(
+                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
                           &vtsn->stat_request_times, vtscf->average_method,
-                          vtscf->average_period),
-                      &upstream, &upstream_server, vtsn->stat_upstream.response_time_counter,
+                          vtscf->average_period) / 1000,
+                      &upstream, &upstream_server, (double) vtsn->stat_upstream.response_time_counter / 1000,
                       &upstream, &upstream_server,
-                      ngx_http_vhost_traffic_status_node_time_queue_average(
+                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
                           &vtsn->stat_upstream.response_times, vtscf->average_method,
-                          vtscf->average_period));
+                          vtscf->average_period) / 1000);
 
     return buf;
 }

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -9,10 +9,12 @@
 
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN                      \
-    "# HELP nginx_vts_main_uptime_seconds_total nginx uptime info\n"           \
-    "# TYPE nginx_vts_main_uptime_seconds_total counter\n"                     \
-    "nginx_vts_main_uptime_seconds_total{hostname=\"%V\","                     \
-    "version=\"%s\"} %.1f\n"                                                   \
+    "# HELP nginx_vts_info nginx info\n"                                       \
+    "# TYPE nginx_vts_info gauge\n"                                            \
+    "nginx_vts_info{hostname=\"%V\",version=\"%s\"} 1\n"                       \
+    "# HELP nginx_vts_start_time_seconds nginx start time\n"                   \
+    "# TYPE nginx_vts_start_time_seconds gauge\n"                              \
+    "nginx_vts_start_time_seconds %.3f\n"                                      \
     "# HELP nginx_vts_main_connections nginx connections\n"                    \
     "# TYPE nginx_vts_main_connections gauge\n"                                \
     "nginx_vts_main_connections{status=\"accepted\"} %uA\n"                    \

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -35,12 +35,12 @@
     "# TYPE nginx_vts_server_bytes_total counter\n"                            \
     "# HELP nginx_vts_server_requests_total requests counter\n"                \
     "# TYPE nginx_vts_server_requests_total counter\n"                         \
-    "# HELP nginx_vts_server_request_msecs_total request processing "          \
-    "time in milliseconds counter\n"                                           \
-    "# TYPE nginx_vts_server_request_msecs_total counter\n"                    \
-    "# HELP nginx_vts_server_request_msecs average of request "                \
-    "processing times in milliseconds\n"                                       \
-    "# TYPE nginx_vts_server_request_msecs gauge\n"
+    "# HELP nginx_vts_server_request_seconds_total request processing "        \
+    "time in seconds\n"                                                        \
+    "# TYPE nginx_vts_server_request_seconds_total counter\n"                  \
+    "# HELP nginx_vts_server_request_seconds average of request "              \
+    "processing times in seconds\n"                                            \
+    "# TYPE nginx_vts_server_request_seconds gauge\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER                    \
     "nginx_vts_server_bytes_total{host=\"%V\",direction=\"in\"} %uA\n"         \
@@ -51,8 +51,8 @@
     "nginx_vts_server_requests_total{host=\"%V\",code=\"4xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"5xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"total\"} %uA\n"        \
-    "nginx_vts_server_request_msecs_total{host=\"%V\"} %uA\n"                  \
-    "nginx_vts_server_request_msecs{host=\"%V\"} %M\n"
+    "nginx_vts_server_request_seconds_total{host=\"%V\"} %.3f\n"               \
+    "nginx_vts_server_request_seconds{host=\"%V\"} %.3f\n"
 
 #if (NGX_HTTP_CACHE)
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE_S            \
@@ -75,12 +75,12 @@
     "# TYPE nginx_vts_filter_bytes_total counter\n"                            \
     "# HELP nginx_vts_filter_requests_total requests counter\n"                \
     "# TYPE nginx_vts_filter_requests_total counter\n"                         \
-    "# HELP nginx_vts_filter_request_msecs_total request processing "          \
-    "time in milliseconds counter\n"                                           \
-    "# TYPE nginx_vts_filter_request_msecs_total counter\n"                    \
-    "# HELP nginx_vts_filter_request_msecs average of request processing "     \
-    "times in milliseconds\n"                                                  \
-    "# TYPE nginx_vts_filter_request_msecs gauge\n"
+    "# HELP nginx_vts_filter_request_seconds_total request processing "        \
+    "time in seconds counter\n"                                                \
+    "# TYPE nginx_vts_filter_request_seconds_total counter\n"                  \
+    "# HELP nginx_vts_filter_request_seconds average of request processing "   \
+    "times in seconds\n"                                                       \
+    "# TYPE nginx_vts_filter_request_seconds gauge\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER                    \
     "nginx_vts_filter_bytes_total{filter=\"%V\",filter_name=\"%V\","           \
@@ -99,9 +99,9 @@
     "direction=\"5xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
     "direction=\"total\"} %uA\n"                                               \
-    "nginx_vts_filter_request_msecs_total{filter=\"%V\","                      \
-    "filter_name=\"%V\"} %uA\n"                                                \
-    "nginx_vts_filter_request_msecs{filter=\"%V\",filter_name=\"%V\"} %M\n"
+    "nginx_vts_filter_request_seconds_total{filter=\"%V\","                    \
+    "filter_name=\"%V\"} %.3f\n"                                               \
+    "nginx_vts_filter_request_seconds{filter=\"%V\",filter_name=\"%V\"} %.3f\n"
 
 #if (NGX_HTTP_CACHE)
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE_S            \
@@ -132,18 +132,18 @@
     "# TYPE nginx_vts_upstream_bytes_total counter\n"                          \
     "# HELP nginx_vts_upstream_requests_total upstream requests counter\n"     \
     "# TYPE nginx_vts_upstream_requests_total counter\n"                       \
-    "# HELP nginx_vts_upstream_request_msecs_total request "                   \
-    "processing time including upstream in milliseconds counter\n"             \
-    "# TYPE nginx_vts_upstream_request_msecs_total counter\n"                  \
-    "# HELP nginx_vts_upstream_request_msecs average of request "              \
-    "processing times including upstream in milliseconds\n"                    \
-    "# TYPE nginx_vts_upstream_request_msecs gauge\n"                          \
-    "# HELP nginx_vts_upstream_response_msecs_total only upstream "            \
-    "response processing time in milliseconds counter\n"                       \
-    "# TYPE nginx_vts_upstream_response_msecs_total counter\n"                 \
-    "# HELP nginx_vts_upstream_response_msecs average of only "                \
-    "upstream response processing times in milliseconds\n"                     \
-    "# TYPE nginx_vts_upstream_response_msecs gauge\n"
+    "# HELP nginx_vts_upstream_request_seconds_total request "                 \
+    "processing time including upstream in seconds counter\n"                  \
+    "# TYPE nginx_vts_upstream_request_seconds_total counter\n"                \
+    "# HELP nginx_vts_upstream_request_seconds average of request "            \
+    "processing times including upstream in seconds\n"                         \
+    "# TYPE nginx_vts_upstream_request_seconds gauge\n"                        \
+    "# HELP nginx_vts_upstream_response_seconds_total only upstream "          \
+    "response processing time in seconds counter\n"                            \
+    "# TYPE nginx_vts_upstream_response_seconds_total counter\n"               \
+    "# HELP nginx_vts_upstream_response_seconds average of only "              \
+    "upstream response processing times in seconds\n"                          \
+    "# TYPE nginx_vts_upstream_response_seconds gauge\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM                  \
     "nginx_vts_upstream_bytes_total{upstream=\"%V\",backend=\"%V\","           \
@@ -162,13 +162,13 @@
     "code=\"5xx\"} %uA\n"                                                      \
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
     "code=\"total\"} %uA\n"                                                    \
-    "nginx_vts_upstream_request_msecs_total{upstream=\"%V\","                  \
-    "backend=\"%V\"} %uA\n"                                                    \
-    "nginx_vts_upstream_request_msecs{upstream=\"%V\","                        \
-    "backend=\"%V\"} %M\n"                                                     \
-    "nginx_vts_upstream_response_msecs_total{upstream=\"%V\","                 \
-    "backend=\"%V\"} %uA\n"                                                    \
-    "nginx_vts_upstream_response_msecs{upstream=\"%V\",backend=\"%V\"} %M\n"
+    "nginx_vts_upstream_request_seconds_total{upstream=\"%V\","                \
+    "backend=\"%V\"} %.3f\n"                                                   \
+    "nginx_vts_upstream_request_seconds{upstream=\"%V\","                      \
+    "backend=\"%V\"} %.3f\n"                                                   \
+    "nginx_vts_upstream_response_seconds_total{upstream=\"%V\","               \
+    "backend=\"%V\"} %.3f\n"                                                   \
+    "nginx_vts_upstream_response_seconds{upstream=\"%V\",backend=\"%V\"} %.3f\n"
 
 #if (NGX_HTTP_CACHE)
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_CACHE_S                   \


### PR DESCRIPTION
This improves the status metrics to conform more closely to Prometheus conventions.

* Use seconds rather than milliseconds for Prometheus metrics, this conforms with the best practice to expose base units[0].
* Separate version info metric from uptime.
  - Allows for queries like `count(nginx_vts_info) by (version)`.
* Use absolute start time rather than uptime.
  - Allows for queries like `changes(nginx_vts_start_time_seconds[1d])` or `time() - nginx_vts_start_time_seconds`.

[0]: https://prometheus.io/docs/practices/naming/#base-units