### PR TITLE
Add support for nginx_upstream_check_module module

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -9,7 +9,9 @@
 #include "ngx_http_vhost_traffic_status_filter.h"
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
-
+#if (NGX_STREAM_UPSTREAM_CHECK)
+#include "ngx_stream_upstream_check_module.h"
+#endif
 
 u_char *
 ngx_http_vhost_traffic_status_display_set_main(ngx_http_request_t *r,
@@ -581,7 +583,15 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
                 usn.max_fails = peer->max_fails;
                 usn.fail_timeout = peer->fail_timeout;
                 usn.backup = 0;
+#if (NGX_STREAM_UPSTREAM_CHECK)
+                if (ngx_stream_upstream_check_peer_down(peer->check_index)) {
+                    usn.down = 1;
+                } else {
+                    usn.down = 0;
+                }
+#else
                 usn.down = (peer->fails >= peer->max_fails || peer->down);
+#endif
 
 #if nginx_version > 1007001
                 usn.name = peer->name;

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -9,8 +9,8 @@
 #include "ngx_http_vhost_traffic_status_filter.h"
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
-#if (NGX_STREAM_UPSTREAM_CHECK)
-#include "ngx_stream_upstream_check_module.h"
+#if (NGX_HTTP_UPSTREAM_CHECK)
+#include "ngx_http_upstream_check_module.h"
 #endif
 
 u_char *
@@ -583,8 +583,8 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
                 usn.max_fails = peer->max_fails;
                 usn.fail_timeout = peer->fail_timeout;
                 usn.backup = 0;
-#if (NGX_STREAM_UPSTREAM_CHECK)
-                if (ngx_stream_upstream_check_peer_down(peer->check_index)) {
+#if (NGX_HTTP_UPSTREAM_CHECK)
+                if (ngx_http_upstream_check_peer_down(peer->check_index)) {
                     usn.down = 1;
                 } else {
                     usn.down = 0;


### PR DESCRIPTION
I believe the nginx_upstream_check_module is widely used for checking upstreams and we find this patch very useful for updating the upstream status  as soon as the healthcheck fails. It check the upstream status if the nginx_upstream_check_module module is enabled/defined.