### PR TITLE
remove redundant comparision, found by cppcheck

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -323,9 +323,7 @@ ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
                 buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
 
                 /* destory array to prevent duplication */
-                if (filter_nodes != NULL) {
-                    filter_nodes = NULL;
-                }
+                filter_nodes = NULL;
             }
 
         }
@@ -336,9 +334,7 @@ ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
                  ngx_pfree(r->pool, keys[i].key.data);
              }
         }
-        if (filter_keys != NULL) {
-            filter_keys = NULL;
-        }
+        filter_keys = NULL;
     }
 
     return buf;


### PR DESCRIPTION
[src/ngx_http_vhost_traffic_status_display_json.c:339] -> [src/ngx_http_vhost_traffic_status_display_json.c:284]: (warning) Either the condition 'filter_keys!=NULL' is redundant or there is possible null pointer dereference: filter_keys.
[src/ngx_http_vhost_traffic_status_display_json.c:339] -> [src/ngx_http_vhost_traffic_status_display_json.c:285]: (warning) Either the condition 'filter_keys!=NULL' is redundant or there is possible null pointer dereference: filter_keys.
[src/ngx_http_vhost_traffic_status_display_json.c:326] -> [src/ngx_http_vhost_traffic_status_display_json.c:315]: (warning) Either the condition 'filter_nodes!=NULL' is redundant or there is possible null pointer dereference: filter_nodes.
[src/ngx_http_vhost_traffic_status_display_json.c:326] -> [src/ngx_http_vhost_traffic_status_display_json.c:316]: (warning) Either the condition 'filter_nodes!=NULL' is redundant or there is possible null pointer dereference: filter_nodes.