### PR TITLE
Add utf8 checks for user defined data inputs shown on Prometheus display page

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -125,7 +125,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_prometheus_set_server(ngx_http_request_t *r,
     u_char *buf, ngx_rbtree_node_t *node)
 {
-    ngx_str_t                                  key;
+    ngx_str_t                                  key, escaped_key;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
@@ -141,7 +141,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server(ngx_http_request_t *
             key.data = vtsn->data;
             key.len = vtsn->len;
 
-            buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &key, vtsn);
+            ngx_hex_escape_invalid_utf8_char(r->pool, &escaped_key, key.data, key.len);
+            buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &escaped_key, vtsn);
 
             /* calculates the sum */
             vtscf->stats.stat_request_counter += vtsn->stat_request_counter;
@@ -268,7 +269,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_prometheus_set_filter(ngx_http_request_t *r,
     u_char *buf, ngx_rbtree_node_t *node)
 {
-    ngx_str_t                              key;
+    ngx_str_t                              key, escaped_key;
     ngx_http_vhost_traffic_status_ctx_t   *ctx;
     ngx_http_vhost_traffic_status_node_t  *vtsn;
 
@@ -281,7 +282,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter(ngx_http_request_t *
             key.data = vtsn->data;
             key.len = vtsn->len;
 
-            buf = ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(r, buf, &key, vtsn);
+            ngx_hex_escape_invalid_utf8_char(r->pool, &escaped_key, key.data, key.len);
+            buf = ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(r, buf, &escaped_key, vtsn);
         }
 
         buf = ngx_http_vhost_traffic_status_display_prometheus_set_filter(r, buf, node->left);
@@ -388,7 +390,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_prometheus_set_upstream(ngx_http_request_t *r,
     u_char *buf, ngx_rbtree_node_t *node)
 {
-    ngx_str_t                              key;
+    ngx_str_t                              key, escaped_key;
     ngx_http_vhost_traffic_status_ctx_t   *ctx;
     ngx_http_vhost_traffic_status_node_t  *vtsn;
 
@@ -403,7 +405,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream(ngx_http_request_t
             key.data = vtsn->data;
             key.len = vtsn->len;
 
-            buf = ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(r, buf, &key, vtsn);
+            ngx_hex_escape_invalid_utf8_char(r->pool, &escaped_key, key.data, key.len);
+            buf = ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(r, buf, &escaped_key, vtsn);
         }
 
         buf = ngx_http_vhost_traffic_status_display_prometheus_set_upstream(r, buf, node->left);
@@ -450,7 +453,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_prometheus_set_cache(ngx_http_request_t *r,
     u_char *buf, ngx_rbtree_node_t *node)
 {
-    ngx_str_t                              key;
+    ngx_str_t                              key, escaped_key;
     ngx_http_vhost_traffic_status_ctx_t   *ctx;
     ngx_http_vhost_traffic_status_node_t  *vtsn;
 
@@ -463,7 +466,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_cache(ngx_http_request_t *r
             key.data = vtsn->data;
             key.len = vtsn->len;
 
-            buf = ngx_http_vhost_traffic_status_display_prometheus_set_cache_node(r, buf, &key, vtsn);
+            ngx_hex_escape_invalid_utf8_char(r->pool, &escaped_key, key.data, key.len);
+            buf = ngx_http_vhost_traffic_status_display_prometheus_set_cache_node(r, buf, &escaped_key, vtsn);
         }
 
         buf = ngx_http_vhost_traffic_status_display_prometheus_set_cache(r, buf, node->left);
@@ -480,6 +484,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
     u_char *buf)
 {
+    ngx_str_t                                 escaped_key;
     u_char                                    *o, *s;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
@@ -505,8 +510,9 @@ ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
 #endif
     buf = ngx_http_vhost_traffic_status_display_prometheus_set_server(r, buf, node);
 
-    buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &vtscf->sum_key,
-                                                                           &vtscf->stats);
+    ngx_hex_escape_invalid_utf8_char(r->pool, &escaped_key, vtscf->sum_key.data, vtscf->sum_key.len);
+    buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &escaped_key, &vtscf->stats);
+    
     /* filterZones */
     o = buf;
 

--- a/src/ngx_http_vhost_traffic_status_string.h
+++ b/src/ngx_http_vhost_traffic_status_string.h
@@ -19,7 +19,8 @@ ngx_int_t ngx_http_vhost_traffic_status_replace_chrc(ngx_str_t *buf,
     u_char in, u_char to);
 ngx_int_t ngx_http_vhost_traffic_status_replace_strc(ngx_str_t *buf,
     ngx_str_t *dst, u_char c);
-
+ngx_int_t ngx_hex_escape_invalid_utf8_char(ngx_pool_t *pool, ngx_str_t *buf, 
+	u_char *p, size_t n);
 
 #endif /* _NGX_HTTP_VTS_STRING_H_INCLUDED_ */
 


### PR DESCRIPTION
Hello @wandenberg | @SuperQ  | @vozlt | @gemfield | @tobilarscheid 

We have been facing a problem with VTS module exposing invalid UTF-8 characters on Prometheus metrics display page. This happens whenever a rouge testing script makes a call to invalid upstream or server containing invalid UTF-8 characters (e.g. ). This breaks the Prometheus scrapper because it does not recognize non-UTF8 characters, resulting in stoppage of our monitoring statistics.

I have added a fix here to check whether labels for Server Zones, Upstream Zones and Filter zones are valid UTF8. I have added a slightly modified function for UTF8 string validation, that is actually based on NGINX's built-in ngx_utf8_length() function.

P.s. The bug is already reported here:  #142 

Pl review and let me know of any shortcomings.

Regards
Furhan