### PR TITLE
Include version as string in compiled module

### DIFF
--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -13,6 +13,7 @@
 #include "ngx_http_vhost_traffic_status_set.h"
 #include "ngx_http_vhost_traffic_status_dump.h"
 
+static const char *NGX_HTTP_VHOST_TRAFFIC_STATUS_VERSION __attribute__((used)) = "ngx_http_vhost_traffic_status_version=0.1.18";
 
 static ngx_int_t ngx_http_vhost_traffic_status_handler(ngx_http_request_t *r);
 


### PR DESCRIPTION
Including the version allows to determine the version after nginx was compiled. This is use full, for example, when using Ansible to automate updating this module.

```console
[user@localhost ~]$ strings /etc/nginx/modules/ngx_http_vhost_traffic_status_module.so | grep ngx_http_vhost_traffic_status_version
ngx_http_vhost_traffic_status_version=0.1.18
```

Ansible playbook example:

```yaml
- name: Get installed NGINX VTS module version
  shell: "strings /etc/nginx/modules/ngx_http_vhost_traffic_status_module.so | grep ngx_http_vhost_traffic_status_version"
  changed_when: false
  ignore_errors: true
  register: nginx_vts_installed_version

- name: Force recompile if versions do not match
  set_fact:
    recompile: true
  when: >
    nginx_vts_installed_version is failed or (
      nginx_vts_installed_version is success and
      nginx_vts_installed_version.stderr |
        regex_replace("^.*=([0-9\.]+)$", "\\1") is
        version_compare(nginx_vts_version, operator="!=")
    )

...
```