### PR TITLE
Prometheus request count label fixes

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -70,7 +70,6 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server_node(
                       &server, vtsn->stat_3xx_counter,
                       &server, vtsn->stat_4xx_counter,
                       &server, vtsn->stat_5xx_counter,
-                      &server, vtsn->stat_request_counter,
                       &server, (double) vtsn->stat_request_time_counter / 1000,
                       &server, (double) ngx_http_vhost_traffic_status_node_time_queue_average(
                                    &vtsn->stat_request_times, vtscf->average_method,
@@ -211,7 +210,6 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(
                       &filter, &filter_name, vtsn->stat_3xx_counter,
                       &filter, &filter_name, vtsn->stat_4xx_counter,
                       &filter, &filter_name, vtsn->stat_5xx_counter,
-                      &filter, &filter_name, vtsn->stat_request_counter,
                       &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000,
                       &filter, &filter_name,
                       (double) ngx_http_vhost_traffic_status_node_time_queue_average(
@@ -325,7 +323,6 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
                       &upstream, &upstream_server, vtsn->stat_3xx_counter,
                       &upstream, &upstream_server, vtsn->stat_4xx_counter,
                       &upstream, &upstream_server, vtsn->stat_5xx_counter,
-                      &upstream, &upstream_server, vtsn->stat_request_counter,
                       &upstream, &upstream_server, (double) vtsn->stat_request_time_counter / 1000,
                       &upstream, &upstream_server,
                       (double) ngx_http_vhost_traffic_status_node_time_queue_average(

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -53,7 +53,6 @@
     "nginx_vts_server_requests_total{host=\"%V\",code=\"3xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"4xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"5xx\"} %uA\n"          \
-    "nginx_vts_server_requests_total{host=\"%V\",code=\"total\"} %uA\n"        \
     "nginx_vts_server_request_seconds_total{host=\"%V\"} %.3f\n"               \
     "nginx_vts_server_request_seconds{host=\"%V\"} %.3f\n"
 
@@ -117,8 +116,6 @@
     "direction=\"4xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
     "direction=\"5xx\"} %uA\n"                                                 \
-    "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"total\"} %uA\n"                                               \
     "nginx_vts_filter_request_seconds_total{filter=\"%V\","                    \
     "filter_name=\"%V\"} %.3f\n"                                               \
     "nginx_vts_filter_request_seconds{filter=\"%V\",filter_name=\"%V\"} %.3f\n"
@@ -202,8 +199,6 @@
     "code=\"4xx\"} %uA\n"                                                      \
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
     "code=\"5xx\"} %uA\n"                                                      \
-    "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
-    "code=\"total\"} %uA\n"                                                    \
     "nginx_vts_upstream_request_seconds_total{upstream=\"%V\","                \
     "backend=\"%V\"} %.3f\n"                                                   \
     "nginx_vts_upstream_request_seconds{upstream=\"%V\","                      \

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -107,15 +107,15 @@
     "nginx_vts_filter_bytes_total{filter=\"%V\",filter_name=\"%V\","           \
     "direction=\"out\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"1xx\"} %uA\n"                                                 \
+    "code=\"1xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"2xx\"} %uA\n"                                                 \
+    "code=\"2xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"3xx\"} %uA\n"                                                 \
+    "code=\"3xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"4xx\"} %uA\n"                                                 \
+    "code=\"4xx\"} %uA\n"                                                 \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "direction=\"5xx\"} %uA\n"                                                 \
+    "code=\"5xx\"} %uA\n"                                                 \
     "nginx_vts_filter_request_seconds_total{filter=\"%V\","                    \
     "filter_name=\"%V\"} %.3f\n"                                               \
     "nginx_vts_filter_request_seconds{filter=\"%V\",filter_name=\"%V\"} %.3f\n"


### PR DESCRIPTION
* Remove `code="total"` instances; this is better computed when needed by Prometheus itself
* Fix label naming