### PR TITLE
Cast key length to correct type

### DIFF
--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -147,7 +147,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
         node->key = hash;
-        vtsn->len = (u_char) key->len;
+        vtsn->len = (u_short) key->len;
         ngx_http_vhost_traffic_status_node_init(r, vtsn);
         vtsn->stat_upstream.type = type;
         ngx_memcpy(vtsn->data, key->data, key->len);


### PR DESCRIPTION
Very small patch to cast the key length to the correct type for the `ngx_http_vhost_traffic_status_node_t`. Without this change, keys over 255 characters are not passed through correctly, and corrupt the output data.