### PR TITLE
Set histogram buckets on first request

### DIFF
--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -118,6 +118,8 @@ void ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn);
 void ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn);
+void ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms);
 
 void ngx_http_vhost_traffic_status_node_time_queue_zero(
     ngx_http_vhost_traffic_status_node_time_queue_t *q);


### PR DESCRIPTION
The `ngx_http_vhost_traffic_status_node_init` function initializes several data structures and then processes the first request. Subsequent requests are then processed by `ngx_http_vhost_traffic_status_node_set`. When histogram buckets were introduced, the `ngx_http_vhost_traffic_status_node_set` function was modified to increment the counters in the buckets. However `ngx_http_vhost_traffic_status_node_init` was not modified to increment the histogram buckets for the first request.

This PR refactors the common code from these functions into a common `ngx_http_vhost_traffic_status_node_update` function to fix this omission and to reduce the chance of similar problems.