### PR TITLE
docs: fix simple typo, destory -> destroy

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -322,7 +322,7 @@ ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
                 buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_OBJECT_E);
                 buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
 
-                /* destory array to prevent duplication */
+                /* destroy array to prevent duplication */
                 if (filter_nodes != NULL) {
                     filter_nodes = NULL;
                 }
@@ -330,7 +330,7 @@ ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
 
         }
 
-        /* destory array */
+        /* destroy array */
         for (i = 0; i < n; i++) {
              if (keys[i].key.data != NULL) {
                  ngx_pfree(r->pool, keys[i].key.data);


### PR DESCRIPTION
There is a small typo in src/ngx_http_vhost_traffic_status_display_json.c.

Should read `destroy` rather than `destory`.

