### PR TITLE
Implement vhost_traffic_status_upstream_no_cache filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 'prepare cpanm'
         run: |
           sudo apt install -y cpanminus
-          sudo cpanm install Test::Nginx::Socket
+          sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
       - name: 'prepare promtool'
         run: |
           sudo apt-get update && sudo apt-get install -y curl

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Table of Contents
   * [vhost_traffic_status_filter_by_set_key](#vhost_traffic_status_filter_by_set_key)
   * [vhost_traffic_status_filter_check_duplicate](#vhost_traffic_status_filter_check_duplicate)
   * [vhost_traffic_status_filter_max_node](#vhost_traffic_status_filter_max_node)
+  * [vhost_traffic_status_filter_upstream_no_cache](#vhost_traffic_status_filter_upstream_no_cache)
   * [vhost_traffic_status_limit](#vhost_traffic_status_limit)
   * [vhost_traffic_status_limit_traffic](#vhost_traffic_status_limit_traffic)
   * [vhost_traffic_status_limit_traffic_by_set_key](#vhost_traffic_status_limit_traffic_by_set_key)
@@ -1478,6 +1479,32 @@ http {
 
 In the above example, the `/^uris.*/` and `/^client::ports.*/` group string patterns are limited to a total of 16 nodes.
 The other filters like `country::.*` are not limited.
+
+### vhost_traffic_status_filter_upstream_no_cache
+
+| -   | - |
+| --- | --- |
+| **Syntax**  | **vhost_traffic_status_filter_upstream_no_cache** *name* |
+| **Default** | - |
+| **Context** | http, server, location |
+
+`Description:` Create a group name that counts requests that have an upstream
+but should not be cached. The group is visible under serverZones.
+Note: This is event is not "cache miss" or "bypass cache". Example:
+`$ edit nginx.conf`
+
+```Nginx
+http {
+    ...
+    vhost_traffic_status_zone;
+    ...
+    server {
+        server_name example.org;
+        ...
+        vhost_traffic_status_filter_upstream_no_cache NO_CACHE;
+    }
+}
+```
 
 ### vhost_traffic_status_limit
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -297,6 +297,9 @@ typedef struct {
     ngx_flag_t                              bypass_limit;
     ngx_flag_t                              bypass_stats;
 
+    /* Controls name of "no cache" server zone */
+    ngx_str_t                              no_cache_server_zone;
+
     ngx_rbtree_node_t                     **node_caches;
 } ngx_http_vhost_traffic_status_loc_conf_t;
 

--- a/src/ngx_http_vhost_traffic_status_shm.h
+++ b/src/ngx_http_vhost_traffic_status_shm.h
@@ -19,7 +19,8 @@ typedef struct {
 } ngx_http_vhost_traffic_status_shm_info_t;
 
 
-ngx_int_t ngx_http_vhost_traffic_status_shm_add_server(ngx_http_request_t *r);
+ngx_int_t ngx_http_vhost_traffic_status_shm_add_server(
+    ngx_http_request_t *r, const ngx_str_t *no_cache_server_zone);
 ngx_int_t ngx_http_vhost_traffic_status_shm_add_filter(ngx_http_request_t *r);
 ngx_int_t ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r);
 


### PR DESCRIPTION
This enables monitoring upstream backend events that are configured not to
use cache.

Add the following line to nginx config to create a group:

        vhost_traffic_status_filter_upstream_no_cache "NO_CACHE";
