### PR TITLE
Docs: Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1736,7 +1736,7 @@ For examples:
 * **vhost_traffic_status_histogram_buckets** `0.005` `0.01` `0.05` `0.1` `0.5` `1` `5` `10`
   * The observe buckets are [5ms 10ms 50ms 1s 5s 10s].
 * **vhost_traffic_status_histogram_buckets** `0.005` `0.01` `0.05` `0.1`
-  * The observe buckets are [5ms 10ms 50ms 1s].
+  * The observe buckets are [5ms 10ms 50ms 100ms].
 
 `Caveats:` By default, if you do not set this directive, the histogram statistics does not work.
 The restored histograms by `vhost_traffic_status_dump` directive have no affected by changes to the buckets


### PR DESCRIPTION
The description of the observe buckets in the vhost_traffic_status_histogram_buckets is incorrect.