### PR TITLE
Release v0.2.0

### DIFF
--- a/.chglog/RELNOTES.tmpl
+++ b/.chglog/RELNOTES.tmpl
@@ -1,0 +1,20 @@
+{{ range .Versions -}}
+Release {{ .Tag.Name}}
+
+Release {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+** {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+** {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+## [v0.2.0] - 2022-09-05
 ### Bugfix
 - fixed for PR[#238](https://github.com/vozlt/nginx-module-vts/issues/238)
 - fixed for PR[#238](https://github.com/vozlt/nginx-module-vts/issues/238)
@@ -11,6 +13,9 @@
 - added escape strings for filter names in JSON
 - fixed the sum value of histogram in upstream metrics
 -  fixed to display all A records of server without zone directive in the upstream block.
+
+### Chore
+- Use git-chglog
 
 ### Comment
 - added moduleVersion
@@ -300,7 +305,8 @@
 - added type casting(ngx_atomic_t) in the ngx_vhost_traffic_status_node_init() and ngx_vhost_traffic_status_node_set()
 
 
-[Unreleased]: https://github.com/vozlt/nginx-module-vts/compare/v0.1.18...HEAD
+[Unreleased]: https://github.com/vozlt/nginx-module-vts/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/vozlt/nginx-module-vts/compare/v0.1.18...v0.2.0
 [v0.1.18]: https://github.com/vozlt/nginx-module-vts/compare/v0.1.17...v0.1.18
 [v0.1.17]: https://github.com/vozlt/nginx-module-vts/compare/v0.1.16...v0.1.17
 [v0.1.16]: https://github.com/vozlt/nginx-module-vts/compare/v0.1.15...v0.1.16

--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ Table of Contents
   * [vhost_traffic_status_histogram_buckets](#vhost_traffic_status_histogram_buckets)
   * [vhost_traffic_status_bypass_limit](#vhost_traffic_status_bypass_limit)
   * [vhost_traffic_status_bypass_stats](#vhost_traffic_status_bypass_stats)
+* [Releases](#releases)
 * [See Also](#see-also)
 * [TODO](#todo)
 * [Donation](#donation)
 * [Author](#author)
 
 ## Version
-This document describes nginx-module-vts `v0.1.18` released on 22 Jun 2018.
+
+![GitHub Release](https://img.shields.io/github/v/release/vozlt/nginx-module-vts?display_name=tag&sort=semver)
+
+See the [GitHub Releases](https://github.com/vozlt/nginx-module-vts/releases) for the latest tagged release.
 
 ## Test
 Run `sudo prove -r t` after you have installed this module. The `sudo` is required because
@@ -1807,6 +1811,18 @@ http {
     }
 }
 ```
+
+## Releases
+
+To cut a release, create a changelog entry PR with [git-chglog](https://github.com/git-chglog/git-chglog)
+
+    version="v0.2.0"
+    git checkout -b "cut-${version}"
+    git-chglog -o CHANGELOG.md --next-tag "${version}"
+    git add CHANGELOG.md
+    git-chglog -t .chglog/RELNOTES.tmpl --next-tag "${version}" "${version}" | git commit -F-
+    
+After the PR is merged, create the new tag and release on the [GitHub Releases](https://github.com/vozlt/nginx-module-vts/releases).
 
 ## See Also
 * Stream traffic status


### PR DESCRIPTION
Release [v0.2.0] - 2022-09-05
** Bugfix
- fixed for PR[#238](https://github.com/vozlt/nginx-module-vts/issues/238)
- fixed for PR[#238](https://github.com/vozlt/nginx-module-vts/issues/238)
- fixed issues/204 that syntax error has occured
- rollback to 549cc4d
- fixed issues/137, issues/98 that maxSize in cacheZones is displayed incorrectly
- fixed issues/174 that XSS vulnerability in the html page Feature: added moduleVersion field in format/json
- added escape strings for filter names in JSON
- fixed the sum value of histogram in upstream metrics
-  fixed to display all A records of server without zone directive in the upstream block.

** Chore
- Use git-chglog

** Comment
- added moduleVersion
- added additional information about cacheZones
- added tested versions
- added a diagram for the order of module directives

** Compatibility
- fixed ngx_http_vhost_traffic_status_display_get_upstream_nelts() to calculate all A records of server.

** Docs
- Fix README

** Docs
- fix simple typo, destory -> destroy

** Fix
- limit the r->uri search scope to avoid overflow

** Prometheus
- fix nginx_vts_filter_requests_total labels
- remove request "total" metrics

** Refactor
- changed version
- changed spacing
- changed spacing
- changed if statement from merged pull/145

** Test
- describe how to test and fix failed test case

Signed-off-by: SuperQ <superq@gmail.com>