### PR TITLE
chore: Change module version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1820,9 +1820,9 @@ To cut a release, create a changelog entry PR with [git-chglog](https://github.c
     git checkout -b "cut-${version}"
     git-chglog -o CHANGELOG.md --next-tag "${version}"
     git add CHANGELOG.md
-    git-chglog -t .chglog/RELNOTES.tmpl --next-tag "${version}" "${version}" | git commit -F-
     sed -i "s/NGX_HTTP_VTS_MODULE_VERSION \".*/NGX_HTTP_VTS_MODULE_VERSION \"${version}\"" src/ngx_http_vhost_traffic_status_module.h
     git add src/ngx_http_vhost_traffic_status_module.h
+    git-chglog -t .chglog/RELNOTES.tmpl --next-tag "${version}" "${version}" | git commit -F-
     
 After the PR is merged, create the new tag and release on the [GitHub Releases](https://github.com/vozlt/nginx-module-vts/releases).
 

--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,8 @@ To cut a release, create a changelog entry PR with [git-chglog](https://github.c
     git-chglog -o CHANGELOG.md --next-tag "${version}"
     git add CHANGELOG.md
     git-chglog -t .chglog/RELNOTES.tmpl --next-tag "${version}" "${version}" | git commit -F-
+    sed -i "s/NGX_HTTP_VTS_MODULE_VERSION \".*/NGX_HTTP_VTS_MODULE_VERSION \"${version}\"" src/ngx_http_vhost_traffic_status_module.h
+    git add src/ngx_http_vhost_traffic_status_module.h
     
 After the PR is merged, create the new tag and release on the [GitHub Releases](https://github.com/vozlt/nginx-module-vts/releases).
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -16,7 +16,7 @@
 #include "ngx_http_vhost_traffic_status_string.h"
 #include "ngx_http_vhost_traffic_status_node.h"
 
-#define NGX_HTTP_VTS_MODULE_VERSION  "0.2.0.dev.b740132"
+#define NGX_HTTP_VTS_MODULE_VERSION  "v0.2.0"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO          0
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA          1

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -16,7 +16,7 @@
 #include "ngx_http_vhost_traffic_status_string.h"
 #include "ngx_http_vhost_traffic_status_node.h"
 
-#define NGX_HTTP_VTS_MODULE_VERSION  "0.1.19.dev.91bdb14"
+#define NGX_HTTP_VTS_MODULE_VERSION  "0.2.0.dev.b740132"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO          0
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA          1

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -16,6 +16,14 @@
 #include "ngx_http_vhost_traffic_status_string.h"
 #include "ngx_http_vhost_traffic_status_node.h"
 
+/*
+ * This version should follow the stable releases.
+ * The format should follow https://semver.org/
+ * 
+ * If a change has some important impact, include the commit short hash here.
+ * I.E "v0.2.0+h0a1s2h"
+ *
+ */
 #define NGX_HTTP_VTS_MODULE_VERSION  "v0.2.0"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO          0


### PR DESCRIPTION
After merging https://github.com/vozlt/nginx-module-vts/pull/240

I found a lack of changing module version...

@SuperQ 
If it does not  automate here, it should be change every time. What can you do that?