### PR TITLE
bugfix: Add shmtx unlock

### DIFF
--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -130,6 +130,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         if (node == NULL) {
             shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
             if (shm_info == NULL) {
+                ngx_shmtx_unlock(&shpool->mutex);
                 return NGX_ERROR;
             }
 


### PR DESCRIPTION
`ngx_http_vhost_traffic_status_shm_add_node` does not unlock if it returns from line 133 nevertheless it acquires the lock at line 107.

https://github.com/vozlt/nginx-module-vts/blob/0009b3bc668a7d73751c4cd8f8c0a161cba96832/src/ngx_http_vhost_traffic_status_shm.c#L107-L133