### PR TITLE
Fix escaping filter_key in prometheus output

### DIFF
--- a/src/ngx_http_vhost_traffic_status_string.c
+++ b/src/ngx_http_vhost_traffic_status_string.c
@@ -187,7 +187,7 @@ ngx_http_vhost_traffic_status_escape_prometheus(ngx_pool_t *pool, ngx_str_t *buf
             }
         } else {
             char_end = pa;
-            if (*char_end > 0xf8 || ngx_utf8_decode(&char_end, last - pa) > 0x10ffff) {
+            if (*pa >= 0xf8 || ngx_utf8_decode(&char_end, last - pa) > 0x10ffff) {
                 break;
             } else {
                 pa = char_end;
@@ -237,7 +237,7 @@ ngx_http_vhost_traffic_status_escape_prometheus(ngx_pool_t *pool, ngx_str_t *buf
             }
         } else {
             char_end = pa;
-            if (*char_end > 0xf8 || ngx_utf8_decode(&char_end, last - pa) > 0x10ffff) {
+            if (*pa >= 0xf8 || ngx_utf8_decode(&char_end, last - pa) > 0x10ffff) {
                 /* invalid UTF-8 - escape single char to allow resynchronization */
                 c = *pa++;
                 /* two slashes are required to be valid encoding for prometheus*/


### PR DESCRIPTION
* Fixes #142
* it can be escaped the 2 - 4 bytes character
in detail, please read below.

https://github.com/vozlt/nginx-module-vts/issues/142#issuecomment-1431427669
