### PR TITLE
Fix vtsn.len type #269

### DIFF
--- a/src/ngx_http_vhost_traffic_status_dump.c
+++ b/src/ngx_http_vhost_traffic_status_dump.c
@@ -393,7 +393,7 @@ ngx_http_vhost_traffic_status_dump_restore(ngx_event_t *ev)
         /* read: data */
         offset += n;
         n = ngx_read_file(&file, buf, vtsn.len, offset);
-        if (n != vtsn.len) {
+        if (n >= 0 && vtsn.len <= SSIZE_MAX && n != (ssize_t) vtsn.len) {
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ev->log, 0,
                           "dump_restore::ngx_read_file() read:%z, data:%z failed",
                           n, vtsn.len);

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -100,7 +100,7 @@ typedef struct {
 #endif
 
     ngx_http_vhost_traffic_status_node_upstream_t          stat_upstream;
-    u_short                                                len;
+    size_t                                                 len;
     u_char                                                 data[1];
 } ngx_http_vhost_traffic_status_node_t;
 

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -148,7 +148,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
         node->key = hash;
-        vtsn->len = (u_short) key->len;
+        vtsn->len = key->len;
         ngx_http_vhost_traffic_status_node_init(r, vtsn);
         vtsn->stat_upstream.type = type;
         ngx_memcpy(vtsn->data, key->data, key->len);


### PR DESCRIPTION
Fixes #269 

The type of ngx_str_t.len is size_t. So it has occured the type mismatch between vtsn->len and key->len.
https://github.com/nginx/nginx/blob/dfe70f74a3558f05142fb552cea239add123d414/src/core/ngx_string.h#L17
OTOH, ngx_read_file returns the value which type is ssize_t, it should realize casting safty between ssize_t and size_t
in ngx_http_vhost_traffic_status_dump_restore.
FYI: https://stackoverflow.com/questions/16086331/cast-ssize-t-or-size-t