### PR TITLE
Support query string encoding for control API #279

### DIFF
--- a/src/ngx_http_vhost_traffic_status_string.c
+++ b/src/ngx_http_vhost_traffic_status_string.c
@@ -161,6 +161,7 @@ ngx_http_vhost_traffic_status_replace_strc(ngx_str_t *buf,
     if (n > 0) {
         buf->len = buf->len - (n * dst->len) + n;
     }
+    *(buf->data + buf->len) = '\0';
 
     return NGX_OK;
 }

--- a/t/007.control_status_group.t
+++ b/t/007.control_status_group.t
@@ -201,3 +201,96 @@ __DATA__
     'OK',
     '{"cacheZones.*cache_(one|two)'
 ]
+
+=== TEST 7: /status/control?cmd=status&group=upstream%40group&zone=%2A
+--- http_config
+    vhost_traffic_status_zone;
+    upstream backend {
+        server localhost;
+    }
+    server {
+        server_name backend;
+    }
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /backend {
+        proxy_set_header Host backend;
+        proxy_pass http://backend;
+    }
+--- user_files eval
+[
+    ['backend/file.txt' => 'upstream@group:OK']
+]
+--- request eval
+[
+    'GET /backend/file.txt',
+    'GET /status/control?cmd=status&group=upstream%40group&zone=%2A',
+]
+--- response_body_like eval
+[
+    'OK',
+    '{"upstreamZones.*backend'
+]
+
+=== TEST 8: /status/control?cmd=status&group=upstream%40group&zone=%2a
+--- http_config
+    vhost_traffic_status_zone;
+    upstream backend {
+        server localhost;
+    }
+    server {
+        server_name backend;
+    }
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /backend {
+        proxy_set_header Host backend;
+        proxy_pass http://backend;
+    }
+--- user_files eval
+[
+    ['backend/file.txt' => 'upstream@group:OK']
+]
+--- request eval
+[
+    'GET /backend/file.txt',
+    'GET /status/control?cmd=status&group=upstream%40group&zone=%2a',
+]
+--- response_body_like eval
+[
+    'OK',
+    '{"upstreamZones.*backend'
+]
+
+=== TEST 9: /status/control?cmd=status&group=server&zone=%3A%3Amain
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- user_files eval
+[
+    ['storage/control/file.txt' => 'server:OK']
+]
+--- request eval
+[
+    'GET /storage/control/file.txt',
+    'GET /status/control?cmd=status&group=server&zone=%3A%3Amain',
+]
+--- response_body_like eval
+[
+    'OK',
+    'hostName'
+]
+

--- a/t/008.control_status_zone.t
+++ b/t/008.control_status_zone.t
@@ -175,3 +175,87 @@ __DATA__
     'OK',
     '{"cache_one"'
 ]
+
+=== TEST 6: /status/control?cmd=status&group=filter&zone=storage%3A%3Alocalhost%40vol0
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location ~ ^/storage/(.+)/.*$ {
+        set $volume $1;
+        vhost_traffic_status_filter_by_set_key $volume storage::$server_name;
+    }
+--- user_files eval
+[
+    ['storage/vol0/file.txt' => 'filter:OK']
+]
+--- request eval
+[
+    'GET /storage/vol0/file.txt',
+    'GET /status/control?cmd=status&group=filter&zone=storage%3A%3Alocalhost%40vol0',
+]
+--- response_body_like eval
+[
+    'OK',
+    '{"vol0"'
+]
+
+=== TEST 7: /status/control?cmd=status&group=upstream%40alone&zone=127.0.0.1%3A1981
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /backend {
+        proxy_set_header Host backend;
+        proxy_pass http://127.0.0.1:1981;
+    }
+--- tcp_listen: 1981
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\n\r\nupstream\@alone:OK"
+--- request eval
+[
+    'GET /backend/file.txt',
+    'GET /status/control?cmd=status&group=upstream%40alone&zone=127.0.0.1%3A1981',
+]
+--- response_body_like eval
+[
+    'OK',
+    '{"server":"127.0.0.1:1981"'
+]
+
+=== TEST 8: /status/control?cmd=status&group=filter&zone=storage%3a%3alocalhost%40vol0
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location ~ ^/storage/(.+)/.*$ {
+        set $volume $1;
+        vhost_traffic_status_filter_by_set_key $volume storage::$server_name;
+    }
+--- user_files eval
+[
+    ['storage/vol0/file.txt' => 'filter:OK']
+]
+--- request eval
+[
+    'GET /storage/vol0/file.txt',
+    'GET /status/control?cmd=status&group=filter&zone=storage%3A%3Alocalhost%40vol0',
+]
+--- response_body_like eval
+[
+    'OK',
+    '{"vol0"'
+]
+


### PR DESCRIPTION
Fixes: #279 

support encoding `@`, `:`, `*` for group and zone.