### PR TITLE
Introduce vhost_traffic_status_stats_by_upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Table of Contents
   * [vhost_traffic_status_histogram_buckets](#vhost_traffic_status_histogram_buckets)
   * [vhost_traffic_status_bypass_limit](#vhost_traffic_status_bypass_limit)
   * [vhost_traffic_status_bypass_stats](#vhost_traffic_status_bypass_stats)
-  * [vhost_traffic_status_stats_by__upstream](#vhost_traffic_status_stats__by_upstream)
+  * [vhost_traffic_status_stats_by_upstream](#vhost_traffic_status_stats_by_upstream)
 * [Releases](#releases)
 * [See Also](#see-also)
 * [TODO](#todo)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Table of Contents
   * [vhost_traffic_status_histogram_buckets](#vhost_traffic_status_histogram_buckets)
   * [vhost_traffic_status_bypass_limit](#vhost_traffic_status_bypass_limit)
   * [vhost_traffic_status_bypass_stats](#vhost_traffic_status_bypass_stats)
+  * [vhost_traffic_status_bypass_upstream_stats](#vhost_traffic_status_bypass_upstream_stats)
 * [Releases](#releases)
 * [See Also](#see-also)
 * [TODO](#todo)
@@ -1808,6 +1809,46 @@ http {
             vhost_traffic_status_bypass_stats on;
             vhost_traffic_status_display;
             vhost_traffic_status_display_format html;
+        }
+    }
+}
+```
+
+### vhost_traffic_status_bypass_upstream_stats
+
+| -   | - |
+| --- | --- |
+| **Syntax**  | **vhost_traffic_status_bypass_upstream_stats** \<on\|off\> |
+| **Default** | off |
+| **Context** | http|
+
+`Description:` Enables or disables to bypass `upstreamZone`.
+The `upstreamZone` in the traffic status stats features is bypassed if this option is enabled.
+In other words, it is excluded from the traffic status stats.
+This is mostly useful if you want to be disable statistics collection for upstream servers to reduce CPU load.
+
+```Nginx
+http {
+    vhost_traffic_status_zone;
+    vhost_traffic_status_bypass_upstream_stats on;
+
+    proxy_cache_path /var/cache/nginx keys_zone=zone1:1m max_size=1g inactive=24h;
+    upstream backend {
+       ...
+    }
+    ...
+
+    server {
+
+        ...
+
+        location /status {
+            vhost_traffic_status_display;
+            vhost_traffic_status_display_format html;
+        }
+        location /backend {
+            proxy_cache zone1;
+            proxy_pass http://backend;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Table of Contents
   * [vhost_traffic_status_histogram_buckets](#vhost_traffic_status_histogram_buckets)
   * [vhost_traffic_status_bypass_limit](#vhost_traffic_status_bypass_limit)
   * [vhost_traffic_status_bypass_stats](#vhost_traffic_status_bypass_stats)
-  * [vhost_traffic_status_bypass_upstream_stats](#vhost_traffic_status_bypass_upstream_stats)
+  * [vhost_traffic_status_stats_by__upstream](#vhost_traffic_status_stats__by_upstream)
 * [Releases](#releases)
 * [See Also](#see-also)
 * [TODO](#todo)
@@ -1814,23 +1814,23 @@ http {
 }
 ```
 
-### vhost_traffic_status_bypass_upstream_stats
+### vhost_traffic_status_stats_by_upstream
 
 | -   | - |
 | --- | --- |
-| **Syntax**  | **vhost_traffic_status_bypass_upstream_stats** \<on\|off\> |
-| **Default** | off |
+| **Syntax**  | **vhost_traffic_status_stats_by_upstream** \<on\|off\> |
+| **Default** | on  |
 | **Context** | http|
 
-`Description:` Enables or disables to bypass `upstreamZone`.
-The `upstreamZone` in the traffic status stats features is bypassed if this option is enabled.
+`Description:` Enables or disables to stats `upstreamZone`.
+The `upstreamZone` in the traffic status stats features is bypassed if this option is disabled.
 In other words, it is excluded from the traffic status stats.
 This is mostly useful if you want to be disable statistics collection for upstream servers to reduce CPU load.
 
 ```Nginx
 http {
     vhost_traffic_status_zone;
-    vhost_traffic_status_bypass_upstream_stats on;
+    vhost_traffic_status_stats_by_upstream off;
 
     proxy_cache_path /var/cache/nginx keys_zone=zone1:1m max_size=1g inactive=24h;
     upstream backend {

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -837,7 +837,7 @@ ngx_http_vhost_traffic_status_display_set(ngx_http_request_t *r,
 
     buf--;
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
-    if (!vtscf->bypass_upstream_stats) {
+    if (vtscf->stats_by_upstream) {
         buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
     }
 
@@ -856,13 +856,13 @@ ngx_http_vhost_traffic_status_display_set(ngx_http_request_t *r,
     } else {
         buf--;
         buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
-        if (!vtscf->bypass_upstream_stats) {
+        if (vtscf->stats_by_upstream) {
             buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
         }
     }
 
     /* upstreamZones */
-    if (!vtscf->bypass_upstream_stats) {
+    if (vtscf->stats_by_upstream) {
         o = buf;
 
         buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_UPSTREAM_S);

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -837,7 +837,9 @@ ngx_http_vhost_traffic_status_display_set(ngx_http_request_t *r,
 
     buf--;
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+    if (!vtscf->bypass_upstream_stats) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+    }
 
     /* filterZones */
     o = buf;
@@ -854,25 +856,29 @@ ngx_http_vhost_traffic_status_display_set(ngx_http_request_t *r,
     } else {
         buf--;
         buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
-        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+        if (!vtscf->bypass_upstream_stats) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+        }
     }
 
     /* upstreamZones */
-    o = buf;
+    if (!vtscf->bypass_upstream_stats) {
+        o = buf;
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_UPSTREAM_S);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_UPSTREAM_S);
 
-    s = buf;
+        s = buf;
 
-    buf = ngx_http_vhost_traffic_status_display_set_upstream_group(r, buf);
+        buf = ngx_http_vhost_traffic_status_display_set_upstream_group(r, buf);
 
-    if (s == buf) {
-        buf = o;
-        buf--;
+        if (s == buf) {
+            buf = o;
+            buf--;
 
-    } else {
-        buf--;
-        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
+        } else {
+            buf--;
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_E);
+        }
     }
 
 #if (NGX_HTTP_CACHE)

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -527,7 +527,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
     }
 
     /* upstreamZones */
-    if (!vtscf->bypass_upstream_stats) {
+    if (vtscf->stats_by_upstream) {
         o = buf;
 
         buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_S);

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -527,16 +527,18 @@ ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
     }
 
     /* upstreamZones */
-    o = buf;
+    if (!vtscf->bypass_upstream_stats) {
+        o = buf;
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_S);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_S);
 
-    s = buf;
+        s = buf;
 
-    buf = ngx_http_vhost_traffic_status_display_prometheus_set_upstream(r, buf, node);
+        buf = ngx_http_vhost_traffic_status_display_prometheus_set_upstream(r, buf, node);
 
-    if (s == buf) {
-        buf = o;
+        if (s == buf) {
+            buf = o;
+        }
     }
 
 #if (NGX_HTTP_CACHE)

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -210,11 +210,11 @@ static ngx_command_t ngx_http_vhost_traffic_status_commands[] = {
       offsetof(ngx_http_vhost_traffic_status_loc_conf_t, bypass_stats),
       NULL },
 
-    { ngx_string("vhost_traffic_status_bypass_upstream_stats"),
+    { ngx_string("vhost_traffic_status_stats_by_upstream"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
-      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, bypass_upstream_stats),
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, stats_by_upstream),
       NULL },
 
     ngx_null_command
@@ -278,7 +278,7 @@ ngx_http_vhost_traffic_status_handler(ngx_http_request_t *r)
                       "handler::shm_add_server() failed");
     }
 
-    if (!vtscf->bypass_upstream_stats) {
+    if (vtscf->stats_by_upstream) {
         rc = ngx_http_vhost_traffic_status_shm_add_upstream(r);
         if (rc != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
@@ -898,7 +898,7 @@ ngx_http_vhost_traffic_status_create_loc_conf(ngx_conf_t *cf)
      *     conf->histogram_buckets = { NULL, ... };
      *     conf->bypass_limit = 0;
      *     conf->bypass_stats = 0;
-     *     conf->bypass_upstream_stats = 0;
+     *     conf->stats_by_upstream = 0;
      */
 
     conf->shm_zone = NGX_CONF_UNSET_PTR;
@@ -918,7 +918,7 @@ ngx_http_vhost_traffic_status_create_loc_conf(ngx_conf_t *cf)
     conf->histogram_buckets = NGX_CONF_UNSET_PTR;
     conf->bypass_limit = NGX_CONF_UNSET;
     conf->bypass_stats = NGX_CONF_UNSET;
-    conf->bypass_upstream_stats = NGX_CONF_UNSET;
+    conf->stats_by_upstream = NGX_CONF_UNSET;
 
     conf->node_caches = ngx_pcalloc(cf->pool, sizeof(ngx_rbtree_node_t *)
                                     * (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG + 1));
@@ -1030,7 +1030,7 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_value(conf->bypass_limit, prev->bypass_limit, 0);
     ngx_conf_merge_value(conf->bypass_stats, prev->bypass_stats, 0);
 
-    ngx_conf_merge_value(conf->bypass_upstream_stats, prev->bypass_upstream_stats, 0);
+    ngx_conf_merge_value(conf->stats_by_upstream, prev->stats_by_upstream, 1);
 
     name = ctx->shm_name;
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -297,6 +297,8 @@ typedef struct {
     ngx_flag_t                              bypass_limit;
     ngx_flag_t                              bypass_stats;
 
+    ngx_flag_t                              bypass_upstream_stats;
+
     ngx_rbtree_node_t                     **node_caches;
 } ngx_http_vhost_traffic_status_loc_conf_t;
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -297,7 +297,7 @@ typedef struct {
     ngx_flag_t                              bypass_limit;
     ngx_flag_t                              bypass_stats;
 
-    ngx_flag_t                              bypass_upstream_stats;
+    ngx_flag_t                              stats_by_upstream;
 
     ngx_rbtree_node_t                     **node_caches;
 } ngx_http_vhost_traffic_status_loc_conf_t;


### PR DESCRIPTION
Add new boolean flag `vhost_traffic_status_stats_by_upstream` to allow disabling statistics collection for upstream servers.

fixes: #292 
