### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report incorrect behavior in this module
+title: "BUG: "
+labels: [bug]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: module version checks
+      options:
+        - label: >
+            I have checked that this issue has not already been reported.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a description of the issue shown in the reproducible example.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Installed Versions
+      placeholder: >
+        % sudo /usr/local/nginx/sbin/nginx -V
+        nginx version: nginx/1.27.0
+        built by gcc 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 
+        configure arguments: --add-module=../nginx-module-vts
+      description: >	
+        Please paste the output of ``nginx -V``
+      value: >
+        <details>
+
+
+        Replace this line with the output of nginx -V
+
+
+        </details>
+    validations:
+      required: true
+  - type: textarea
+    id: conf
+    attributes:
+      label: Reproducible Example nginx.conf
+      description: >	
+        Please paste the reproducible nginx.conf

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest an idea for this module
+title: "ENH: "
+labels: [enhancement]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Feature Type
+      description: Please check what type of feature request you would like to propose.
+      options:
+        - label: >
+            Adding new functionality to this module
+        - label: >
+            Changing existing functionality in this module
+        - label: >
+            Removing existing functionality in this module
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem Description
+      description: >
+        Please describe what problem the feature would solve, e.g. "I wish I could use this module to ..."
+      placeholder: >
+        I wish I could use this module...
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: >
+        Please describe how the new feature would be implemented, using psudocode if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any relevant GitHub issues, code examples or references that help describe and support the feature request.

--- a/.github/ISSUE_TEMPLATE/submit_question.yaml
+++ b/.github/ISSUE_TEMPLATE/submit_question.yaml
@@ -1,0 +1,38 @@
+name: Submit Question
+description: Ask a general question about this module
+title: ""
+labels: [question]
+
+body:
+  - type: markdown
+    attributes:
+      value: ---
+  - type: textarea
+    id: question
+    attributes:
+      label: Question about this module
+  - type: textarea
+    id: version
+    attributes:
+      label: Installed Versions
+      placeholder: >
+        % sudo /usr/local/nginx/sbin/nginx -V
+        nginx version: nginx/1.27.0
+        built by gcc 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 
+        configure arguments: --add-module=../nginx-module-vts
+      description: >	
+        Please paste the output of ``nginx -V``
+      value: >
+        <details>
+
+
+        Replace this line with the output of nginx -V
+
+
+        </details>
+  - type: textarea
+    id: conf
+    attributes:
+      label: Reproducible Example nginx.conf
+      description: >	
+        Please paste the reproducible nginx.conf


### PR DESCRIPTION
Add issue template not only to be able to describe the feature or the bug report details without ambiguity for users but also to prevent to disgust or make difficulty to watching or triaging the issues.