### PR TITLE
Issue 315

### DIFF
--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -59,6 +59,15 @@ static ngx_conf_enum_t  ngx_http_vhost_traffic_status_average_method_post[] = {
     { ngx_null_string, 0 }
 };
 
+static ngx_conf_bitmask_t ngx_http_vhost_traffic_status_ignore_status_masks[] = {
+    { ngx_string("1xx"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_1XX },
+    { ngx_string("2xx"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_2XX },
+    { ngx_string("3xx"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_3XX },
+    { ngx_string("4xx"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_4XX },
+    { ngx_string("5xx"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_5XX },
+    { ngx_string("off"), NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_OFF },
+    { ngx_null_string, 0 }
+};
 
 static ngx_command_t ngx_http_vhost_traffic_status_commands[] = {
 
@@ -216,6 +225,13 @@ static ngx_command_t ngx_http_vhost_traffic_status_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_vhost_traffic_status_loc_conf_t, stats_by_upstream),
       NULL },
+
+    { ngx_string("vhost_traffic_status_ignore_status"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+      ngx_conf_set_bitmask_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, ignore_status),
+      &ngx_http_vhost_traffic_status_ignore_status_masks },
 
     ngx_null_command
 };
@@ -1031,6 +1047,8 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_value(conf->bypass_stats, prev->bypass_stats, 0);
 
     ngx_conf_merge_value(conf->stats_by_upstream, prev->stats_by_upstream, 1);
+    ngx_conf_merge_bitmask_value(conf->ignore_status, prev->ignore_status,
+(NGX_CONF_BITMASK_SET|NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_OFF));
 
     name = ctx->shm_name;
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -55,6 +55,13 @@
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_AVG_PERIOD   60
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_DUMP_PERIOD  60
 
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_OFF     0x0002
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_1XX     0x0004
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_2XX     0x0008
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_3XX     0x0010
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_4XX     0x0020
+#define  NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_5XX     0x0040
+
 #define ngx_http_vhost_traffic_status_add_rc(s, n) {                           \
     if(s < 200) {n->stat_1xx_counter++;}                                       \
     else if(s < 300) {n->stat_2xx_counter++;}                                  \
@@ -62,6 +69,8 @@
     else if(s < 500) {n->stat_4xx_counter++;}                                  \
     else {n->stat_5xx_counter++;}                                              \
 }
+
+#define ngx_http_vhost_traffic_status_ignore_status(i, s) (                    (((i & (1<<2)) && 100 <= s && s < 200)                                       || ((i & (1<<3)) && 200 <= s && s < 300)                                   || ((i & (1<<4)) && 300 <= s && s < 400)                                   || ((i & (1<<5)) && 400 <= s && s < 500)                                   || ((i & (1<<6)) && 500 <= s && s < 600)) ? 1 : 0)
 
 #if (NGX_HTTP_CACHE)
 
@@ -298,6 +307,7 @@ typedef struct {
     ngx_flag_t                              bypass_stats;
 
     ngx_flag_t                              stats_by_upstream;
+    ngx_uint_t                              ignore_status;
 
     ngx_rbtree_node_t                     **node_caches;
 } ngx_http_vhost_traffic_status_loc_conf_t;

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -362,6 +362,7 @@ ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
 
     ovtsn = *vtsn;
 
+    vtsn->ignore_status = vtscf->ignore_status;
     ms = ngx_http_vhost_traffic_status_request_time(r);
     ngx_http_vhost_traffic_status_node_update(r, vtsn, ms);
 
@@ -378,6 +379,10 @@ ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms)
 {
     ngx_uint_t status = r->headers_out.status;
+
+    if (ngx_http_vhost_traffic_status_ignore_status(vtsn->ignore_status, status)) {
+        return;
+    }
 
     vtsn->stat_request_counter++;
     vtsn->stat_in_bytes += (ngx_atomic_uint_t) r->request_length;

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -11,7 +11,6 @@
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_QUEUE_LEN    64
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_BUCKET_LEN   32
 
-
 typedef struct {
     ngx_msec_t                                             time;
     ngx_msec_int_t                                         msec;
@@ -102,6 +101,7 @@ typedef struct {
     ngx_http_vhost_traffic_status_node_upstream_t          stat_upstream;
     size_t                                                 len;
     u_char                                                 data[1];
+    ngx_uint_t                                             ignore_status;
 } ngx_http_vhost_traffic_status_node_t;
 
 

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -100,8 +100,8 @@ typedef struct {
 
     ngx_http_vhost_traffic_status_node_upstream_t          stat_upstream;
     size_t                                                 len;
-    u_char                                                 data[1];
     ngx_uint_t                                             ignore_status;
+    u_char                                                 data[1];
 } ngx_http_vhost_traffic_status_node_t;
 
 

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -149,6 +149,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
         node->key = hash;
         vtsn->len = key->len;
+        vtsn->ignore_status = vtscf->ignore_status;
         ngx_http_vhost_traffic_status_node_init(r, vtsn);
         vtsn->stat_upstream.type = type;
         ngx_memcpy(vtsn->data, key->data, key->len);


### PR DESCRIPTION
Fixes: #315 

Add new directive `ignore_status`

If we’d like to observe to eliminate the metrics data of specific status code (e.g. 1xx and 3xx), we can specify their code like this.
```
vhost_traffic_status_ignore_status 1xx 3xx;
```