### PR TITLE
Fix invalid output when upstream re-resolved

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -607,6 +607,55 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
 
             zone = 1;
 
+#if nginx_version > 1027003
+            for (peers = uscf->peer.data; peers; peers = peers->next) {
+                ngx_http_upstream_rr_peers_rlock(peers);
+                for (peer = peers->peer; peer; peer = peer->next) {
+                    p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
+                    *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
+                    p = ngx_cpymem(p, peer->name.data, peer->name.len);
+
+                    dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
+
+                    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
+                    if (rc != NGX_OK) {
+                        ngx_http_upstream_rr_peers_unlock(peers);
+                        return buf;
+                    }
+
+                    hash = ngx_crc32_short(key.data, key.len);
+                    node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
+
+                    usn.weight = peer->weight;
+                    usn.max_fails = peer->max_fails;
+                    usn.fail_timeout = peer->fail_timeout;
+                    usn.backup = 0;
+#if (NGX_HTTP_UPSTREAM_CHECK)
+                    if (ngx_http_upstream_check_peer_down(peer->check_index)) {
+                        usn.down = 1;
+
+                    } else {
+                        usn.down = 0;
+                    }
+#else
+                    usn.down = (peer->fails >= peer->max_fails || peer->down);
+#endif
+
+                    usn.name = peer->name;
+
+                    if (node != NULL) {
+                        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn);
+                    } else {
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL);
+                    }
+                    p = dst.data;
+                }
+                ngx_http_upstream_rr_peers_unlock(peers);
+            }
+            goto last;
+#endif
+
             peers = uscf->peer.data;
 
             ngx_http_upstream_rr_peers_rlock(peers);
@@ -718,6 +767,7 @@ not_supported:
                 }
             }
 
+last:
             if (s == buf) {
                 buf = o;
 


### PR DESCRIPTION
#318 

Unfortunately it is necessary to fix drastic the conventional upstream peers metrics gaining method to obtain all peers data in the past resolved.
That issue should be reconsidered as another one.
This PR holds only to fix invaild output.