### PR TITLE
ci: temporarily disable FreeNginx CI due to lua-nginx-module compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
         with:
           repository: nginx/nginx
           path: nginx
-      - name: 'checkout freenginx'
-        uses: actions/checkout@v3
-        with:
-          repository: freenginx/nginx
-          path: freenginx
+      # - name: 'checkout freenginx'
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: freenginx/nginx
+      #     path: freenginx
       - name: 'checkout luajit2'
         uses: actions/checkout@v3
         with:
@@ -73,10 +73,10 @@ jobs:
         working-directory: nginx
         run: |
           patch -p1 < /home/runner/work/nginx-module-vts/nginx-module-vts/nginx_upstream_check/check_1.20.1+.patch
-      - name: 'patch upstream_check for freenginx'
-        working-directory: freenginx
-        run: |
-          patch -p1 < /home/runner/work/nginx-module-vts/nginx-module-vts/nginx_upstream_check/check_1.20.1+.patch
+      # - name: 'patch upstream_check for freenginx'
+      #   working-directory: freenginx
+      #   run: |
+      #     patch -p1 < /home/runner/work/nginx-module-vts/nginx-module-vts/nginx_upstream_check/check_1.20.1+.patch
       - name: 'build nginx'
         working-directory: nginx
         run: |
@@ -87,16 +87,16 @@ jobs:
         env:
           LUAJIT_LIB: /usr/local/lib
           LUAJIT_INC: /usr/local/include/luajit-2.1
-      - name: 'build freenginx'
-        working-directory: freenginx
-        run: |
-          ./auto/configure --prefix=/usr/local/freenginx --with-ld-opt="-Wl,-rpath,/usr/local/lib" --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/ngx_devel_kit --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/lua-nginx-module --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx_upstream_check
-          make
-          sudo make install
-          /usr/local/freenginx/sbin/nginx -V
-        env:
-          LUAJIT_LIB: /usr/local/lib
-          LUAJIT_INC: /usr/local/include/luajit-2.1
+      # - name: 'build freenginx'
+      #   working-directory: freenginx
+      #   run: |
+      #     ./auto/configure --prefix=/usr/local/freenginx --with-ld-opt="-Wl,-rpath,/usr/local/lib" --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/ngx_devel_kit --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/lua-nginx-module --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx_upstream_check
+      #     make
+      #     sudo make install
+      #     /usr/local/freenginx/sbin/nginx -V
+      #   env:
+      #     LUAJIT_LIB: /usr/local/lib
+      #     LUAJIT_INC: /usr/local/include/luajit-2.1
       - name: 'prepare cpanm'
         run: |
           sudo apt install -y cpanminus
@@ -117,13 +117,13 @@ jobs:
         run: |
           echo "/usr/local/nginx/sbin/" >> $GITHUB_PATH
           sudo TEST_UPSTREAM_CHECK=1 TEST_NGINX_SLEEP=1 PATH=/usr/local/nginx/sbin:$PATH prove t/024.upstream_check.t
-      - name: 'test freenginx'
-        working-directory: nginx-module-vts
-        run: |
-          echo "/usr/local/freenginx/sbin/" >> $GITHUB_PATH
-          sudo PATH=/usr/local/freenginx/sbin:$PATH prove -r t
-      - name: 'test upstream check for freenginx'
-        working-directory: nginx-module-vts
-        run: |
-          echo "/usr/local/freenginx/sbin/" >> $GITHUB_PATH
-          sudo TEST_UPSTREAM_CHECK=1 TEST_NGINX_SLEEP=1 PATH=/usr/local/freenginx/sbin:$PATH prove t/024.upstream_check.t
+      # - name: 'test freenginx'
+      #   working-directory: nginx-module-vts
+      #   run: |
+      #     echo "/usr/local/freenginx/sbin/" >> $GITHUB_PATH
+      #     sudo PATH=/usr/local/freenginx/sbin:$PATH prove -r t
+      # - name: 'test upstream check for freenginx'
+      #   working-directory: nginx-module-vts
+      #   run: |
+      #     echo "/usr/local/freenginx/sbin/" >> $GITHUB_PATH
+      #     sudo TEST_UPSTREAM_CHECK=1 TEST_NGINX_SLEEP=1 PATH=/usr/local/freenginx/sbin:$PATH prove t/024.upstream_check.t


### PR DESCRIPTION
## Summary
Temporarily disables FreeNginx CI steps due to incompatibility with lua-nginx-module build process.

## Problem
FreeNginx introduced breaking changes in [commit 3329aa9d66](https://github.com/freenginx/nginx/commit/3329aa9d66a78d147a3a5186004f5122bfa9277a) that cause lua-nginx-module to fail during build:

- **Removed:** `start_sec` and `start_msec` fields from `ngx_http_request_t`
- **Added:** `start_time` field using monotonic time
- **Impact:** lua-nginx-module accesses removed struct members, causing build failure

## Changes
Commented out all FreeNginx-related CI steps:
- ✅ `checkout freenginx` 
- ✅ `patch upstream_check for freenginx`
- ✅ `build freenginx`
- ✅ `test freenginx`
- ✅ `test upstream check for freenginx`

## Why This Approach
- **Preserves functionality:** All FreeNginx steps are preserved as comments for easy restoration
- **Fixes CI:** Allows CI to pass by testing only against standard nginx
- **Temporary solution:** Can be easily reverted once upstream compatibility is resolved

## Related
- **Filed upstream issue:** https://github.com/freenginx/nginx/issues/13
- **Failed CI run:** https://github.com/vozlt/nginx-module-vts/actions/runs/16381462851/job/46293696855

## Next Steps
1. Monitor upstream issue for resolution
2. Re-enable FreeNginx CI when compatibility is restored
3. Consider this a temporary workaround until lua-nginx-module supports FreeNginx

🤖 Generated with [Claude Code](https://claude.ai/code)