### PR TITLE
Fix initialize vtsn->stat_status_code_counter

### DIFF
--- a/src/ngx_http_vhost_traffic_status_dump.c
+++ b/src/ngx_http_vhost_traffic_status_dump.c
@@ -300,6 +300,10 @@ ngx_http_vhost_traffic_status_dump_restore_add_node(ngx_event_t *ev,
 
         *vtsn = *ovtsn;
 
+        /* invalidate pointers serialized from the old process */
+        vtsn->stat_status_code_counter = NULL;
+        vtsn->stat_status_code_length = 0;
+
         ngx_memcpy(vtsn->data, key->data, key->len);
 
         ngx_rbtree_insert(ctx->rbtree, node);


### PR DESCRIPTION
https://github.com/vozlt/nginx-module-vts/blob/625fc9c04ab1c80e6c815872705454a6a04703c8/src/ngx_http_vhost_traffic_status_dump.c#L301

vtsn copies the dumped value from ovtsn in dump_restore_add_node()

Because stat_status_code_counter is a pointer, its value dumped into the file as it is. Thus it is possible to reference the old process pointer value, it must be the segmentation fault.

reproduction: enable vhost_traffic_status_measure_status_codes + enable vhost_traffic_status_dump, when we restart nginx process.