### PR TITLE
fix: skip subrequests in LOG_PHASE handler and avoid cache lock nesting (P0 SIGSEGV + P1 deadlock risk)

### DIFF
--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -293,6 +293,9 @@ ngx_http_vhost_traffic_status_handler(ngx_http_request_t *r)
     if (!ctx->enable || !vtscf->enable || vtscf->bypass_stats) {
         return NGX_DECLINED;
     }
+    if (r != r->main) {
+        return NGX_DECLINED;
+    }
     if (vtscf->shm_zone == NULL) {
         return NGX_DECLINED;
     }

--- a/src/ngx_http_vhost_traffic_status_set.c
+++ b/src/ngx_http_vhost_traffic_status_set.c
@@ -40,6 +40,9 @@ ngx_http_vhost_traffic_status_set_handler(ngx_http_request_t *r)
     if (!ctx->enable || !vtscf->filter) {
         return NGX_DECLINED;
     }
+    if (r != r->main) {
+        return NGX_DECLINED;
+    }
 
     rc = ngx_http_vhost_traffic_status_set_by_filter_variables(r);
     if (rc != NGX_OK) {

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -15,8 +15,11 @@ static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_re
     ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init);
 
 #if (NGX_HTTP_CACHE)
+static ngx_int_t ngx_http_vhost_traffic_status_shm_get_cache_size(ngx_http_request_t *r,
+    ngx_atomic_uint_t *cache_max_size, ngx_atomic_uint_t *cache_used_size);
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init);
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init,
+    ngx_atomic_uint_t cache_max_size, ngx_atomic_uint_t cache_used_size);
 #endif
 
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_filter_node(ngx_http_request_t *r,
@@ -87,6 +90,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     size_t                                     size;
     unsigned                                   init;
     uint32_t                                   hash;
+    ngx_int_t                                  rc;
     ngx_int_t                                  status_code_slot;
     ngx_slab_pool_t                           *shpool;
     ngx_rbtree_node_t                         *node, *lrun;
@@ -94,6 +98,9 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
     ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
+#if (NGX_HTTP_CACHE)
+    ngx_atomic_uint_t                          cache_max_size, cache_used_size;
+#endif
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
 
@@ -104,6 +111,19 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     }
 
     shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
+
+#if (NGX_HTTP_CACHE)
+    cache_max_size = 0;
+    cache_used_size = 0;
+
+    if (type == NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC) {
+        rc = ngx_http_vhost_traffic_status_shm_get_cache_size(r, &cache_max_size,
+                                                              &cache_used_size);
+        if (rc != NGX_OK) {
+            return rc;
+        }
+    }
+#endif
 
 
     status_code_slot = 0;
@@ -213,7 +233,9 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
 #if (NGX_HTTP_CACHE)
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC:
-        (void) ngx_http_vhost_traffic_status_shm_add_node_cache(r, vtsn, init);
+        (void) ngx_http_vhost_traffic_status_shm_add_node_cache(r, vtsn, init,
+                                                                cache_max_size,
+                                                                cache_used_size);
         break;
 #endif
 
@@ -270,8 +292,8 @@ ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
 #if (NGX_HTTP_CACHE)
 
 static ngx_int_t
-ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init)
+ngx_http_vhost_traffic_status_shm_get_cache_size(ngx_http_request_t *r,
+    ngx_atomic_uint_t *cache_max_size, ngx_atomic_uint_t *cache_used_size)
 {
     ngx_http_cache_t       *c;
     ngx_http_upstream_t    *u;
@@ -279,36 +301,40 @@ ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
 
     u = r->upstream;
 
-    if (u != NULL && u->cache_status != 0 && r->cache != NULL) {
-        c = r->cache;
-        cache = c->file_cache;
-
-    } else {
+    if (u == NULL || u->cache_status == 0 || r->cache == NULL) {
         return NGX_OK;
     }
 
-    /*
-     * If max_size in proxy_cache_path directive is not specified,
-     * the system dependent value NGX_MAX_OFF_T_VALUE is assigned by default.
-     *
-     * proxy_cache_path ... keys_zone=name:size [max_size=size] ...
-     *
-     *     keys_zone's shared memory size:
-     *         cache->shm_zone->shm.size
-     *
-     *     max_size's size:
-     *         cache->max_size
-     */
+    c = r->cache;
+    cache = c->file_cache;
+
+    *cache_max_size = (ngx_atomic_uint_t) (cache->max_size * cache->bsize);
+
+    ngx_shmtx_lock(&cache->shpool->mutex);
+    *cache_used_size = (ngx_atomic_uint_t) (cache->sh->size * cache->bsize);
+    ngx_shmtx_unlock(&cache->shpool->mutex);
+
+    return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init,
+    ngx_atomic_uint_t cache_max_size, ngx_atomic_uint_t cache_used_size)
+{
+    ngx_http_upstream_t    *u;
+
+    u = r->upstream;
+
+    if (u == NULL || u->cache_status == 0 || r->cache == NULL) {
+        return NGX_OK;
+    }
 
     if (init == NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_NONE) {
-        vtsn->stat_cache_max_size = (ngx_atomic_uint_t) (cache->max_size * cache->bsize);
+        vtsn->stat_cache_max_size = cache_max_size;
 
     } else {
-        ngx_shmtx_lock(&cache->shpool->mutex);
-
-        vtsn->stat_cache_used_size = (ngx_atomic_uint_t) (cache->sh->size * cache->bsize);
-
-        ngx_shmtx_unlock(&cache->shpool->mutex);
+        vtsn->stat_cache_used_size = cache_used_size;
     }
 
     return NGX_OK;
@@ -479,7 +505,7 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
     ngx_http_upstream_main_conf_t  *umcf;
 
     if (r->upstream_states == NULL || r->upstream_states->nelts == 0
-        || r->upstream->state == NULL)
+        || r->upstream == NULL || r->upstream->state == NULL)
     {
         return NGX_OK;
     }


### PR DESCRIPTION
## Problem

When nginx processes requests that generate a large number of internal background subrequests (via `NGX_HTTP_SUBREQUEST_BACKGROUND`), each subrequest triggers VTS's `NGX_HTTP_LOG_PHASE` handler and the filter `ACCESS_PHASE` handler. This causes three bugs:

### Bug 1 (P0 — SIGSEGV): `r->upstream` NULL dereference in `shm_add_upstream()`

**File**: `src/ngx_http_vhost_traffic_status_shm.c`

```c
// Before fix — r->upstream is checked for NULL *after* being dereferenced:
if (r->upstream_states == NULL || r->upstream_states->nelts == 0
    || r->upstream->state == NULL)   // ← SIGSEGV if r->upstream == NULL
```

A subrequest can have `r->upstream_states != NULL` (partially initialized or inherited) while `r->upstream == NULL`. Dereferencing `r->upstream->state` crashes the worker.

**Observed symptom**: 3 nginx worker processes crash with SIGSEGV (signal 11) after a batch background subrequest operation completes (e.g. 100,000+ subrequests).

### Bug 2 (P0 — incorrect stats): subrequests counted as independent requests

**Files**: `src/ngx_http_vhost_traffic_status_module.c`, `src/ngx_http_vhost_traffic_status_set.c`

VTS's `NGX_HTTP_LOG_PHASE` handler has no guard against subrequests. Every background subrequest is counted as a separate request in `shm_add_server()`, `shm_add_upstream()`, `shm_add_filter()`, and `shm_add_cache()`, producing severely inflated statistics and unnecessary shared-memory mutex contention.

### Bug 3 (P1 — deadlock risk): nested mutex acquisition in `shm_add_node_cache()`

**File**: `src/ngx_http_vhost_traffic_status_shm.c`

`shm_add_node_cache()` is called while the VTS slab mutex (`shpool->mutex`) is already held. Inside it, it acquires `cache->shpool->mutex` — a *different* shared-memory zone's mutex:

```c
// shm_add_node() holds shpool->mutex here
ngx_shmtx_lock(&cache->shpool->mutex);   // ← nested lock, different shpool
vtsn->stat_cache_used_size = ...;
ngx_shmtx_unlock(&cache->shpool->mutex);
```

If any other code path (e.g. the nginx cache manager) acquires `cache->shpool->mutex` first and then tries to interact with VTS, the reversed lock order can deadlock the worker.

## Fix

### Bug 1 + Bug 2: add subrequest guard

```c
// In both module.c and set.c, immediately after the enable check:
if (r != r->main) {
    return NGX_DECLINED;
}
```

Also add the missing NULL check in `shm_add_upstream()`:

```c
if (r->upstream_states == NULL || r->upstream_states->nelts == 0
    || r->upstream == NULL || r->upstream->state == NULL)
```

### Bug 3: read cache sizes before acquiring VTS slab mutex

Extract cache size reading into a new `shm_get_cache_size()` helper that is called **before** `ngx_shmtx_lock(&shpool->mutex)`. The VTS node update (`shm_add_node_cache()`) then receives the already-read values as parameters and no longer needs to acquire any lock:

```
[Before] shm_add_node() locks VTS mutex → calls shm_add_node_cache() → locks cache mutex  (nested!)
[After]  shm_get_cache_size() locks+unlocks cache mutex → shm_add_node() locks VTS mutex → shm_add_node_cache() uses pre-read values (no lock)
```

## Changes

- `src/ngx_http_vhost_traffic_status_module.c` — subrequest guard (`r != r->main`)
- `src/ngx_http_vhost_traffic_status_set.c` — subrequest guard (`r != r->main`)
- `src/ngx_http_vhost_traffic_status_shm.c` — `r->upstream` NULL check; extract `shm_get_cache_size()`; pass sizes as parameters to `shm_add_node_cache()`