### PR TITLE
Fix heap buffer overflow in the status display for long node names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,65 @@ jobs:
         run: |
           echo "/usr/local/freenginx/sbin/" >> $GITHUB_PATH
           sudo PATH=/usr/local/freenginx/sbin:$PATH prove -r t
+
+  asan:
+    name: 'asan'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: nginx-module-vts
+      - name: 'checkout nginx'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: nginx/nginx
+          path: nginx
+          ref: 'a92a537860c7b87d3793d9eb41c9cf3ed833b53c'
+      - name: 'prepare cpanm'
+        run: |
+          sudo apt install -y cpanminus
+          sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
+      - name: 'prepare promtool'
+        run: |
+          sudo apt-get update && sudo apt-get install -y curl
+          curl -L $(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4) -o prometheus-latest.tar.gz
+          tar xvf prometheus-latest.tar.gz
+          sudo mv prometheus-*/promtool /usr/local/bin
+      - name: 'relax ASLR entropy'
+        # the sanitizer runtime cannot map its shadow memory with the high
+        # entropy ASLR of the ubuntu-24.04 kernel
+        run: sudo sysctl -w vm.mmap_rnd_bits=28 || true
+      - name: 'build nginx with AddressSanitizer'
+        working-directory: nginx
+        run: |
+          ./auto/configure \
+            --prefix=/usr/local/nginx-asan \
+            --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \
+            --with-cc-opt="-fsanitize=address -fno-omit-frame-pointer -g -O1" \
+            --with-ld-opt="-fsanitize=address"
+          make -j$(nproc)
+          sudo make install
+          /usr/local/nginx-asan/sbin/nginx -V
+      - name: 'test under AddressSanitizer'
+        working-directory: nginx-module-vts
+        run: |
+          # the nginx workers drop privileges, so they need to be able to
+          # write their own report files
+          sudo mkdir -p /tmp/asan && sudo chmod 777 /tmp/asan
+          # the lua tests need modules that are not part of this build
+          sudo ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:disable_coredump=1:log_path=/tmp/asan/vts \
+               PATH=/usr/local/nginx-asan/sbin:$PATH prove $(ls t/*.t | grep -v '_by_lua')
+      - name: 'check AddressSanitizer reports'
+        if: always()
+        run: |
+          if compgen -G '/tmp/asan/vts.*' > /dev/null; then
+            echo '::error::AddressSanitizer reported memory errors'
+            cat /tmp/asan/vts.*
+            exit 1
+          fi
+          echo 'no AddressSanitizer reports'
+      - name: 'dump nginx error log'
+        if: failure()
+        working-directory: nginx-module-vts
+        run: sudo tail -n 100 t/servroot/logs/error.log || true

--- a/src/ngx_http_vhost_traffic_status_display.c
+++ b/src/ngx_http_vhost_traffic_status_display.c
@@ -17,6 +17,14 @@ static ngx_int_t ngx_http_vhost_traffic_status_display_handler(ngx_http_request_
 static ngx_int_t ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r);
 static ngx_int_t ngx_http_vhost_traffic_status_display_handler_default(ngx_http_request_t *r);
 
+static ngx_uint_t ngx_http_vhost_traffic_status_display_node_name_repeat(
+    ngx_http_request_t *r, ngx_int_t format);
+static size_t ngx_http_vhost_traffic_status_display_node_fixed_size(
+    ngx_http_request_t *r, ngx_int_t format);
+static void ngx_http_vhost_traffic_status_display_get_size_node(
+    ngx_http_request_t *r, ngx_rbtree_node_t *node, ngx_int_t format,
+    size_t *size);
+
 
 static ngx_int_t
 ngx_http_vhost_traffic_status_display_handler(ngx_http_request_t *r)
@@ -75,6 +83,8 @@ ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r)
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    vtscf->display_buf_end = NULL;
 
     /* init control */
     control = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_control_t));
@@ -265,6 +275,8 @@ ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r)
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
+    vtscf->display_buf_end = b->end;
+
     control->buf = &b->last;
 
     shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
@@ -334,6 +346,8 @@ ngx_http_vhost_traffic_status_display_handler_default(ngx_http_request_t *r)
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
 
     vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    vtscf->display_buf_end = NULL;
 
     if (!ctx->enable) {
         return NGX_HTTP_NOT_IMPLEMENTED;
@@ -445,6 +459,8 @@ ngx_http_vhost_traffic_status_display_handler_default(ngx_http_request_t *r)
                       "display_handler_default::ngx_create_temp_buf() failed");
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
+
+    vtscf->display_buf_end = b->end;
 
     if (format == NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON) {
         shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
@@ -572,15 +588,180 @@ not_supported:
 }
 
 
+/*
+ * Returns how many times the name of a single node can appear in the output
+ * of that node.
+ */
+static ngx_uint_t
+ngx_http_vhost_traffic_status_display_node_name_repeat(ngx_http_request_t *r,
+    ngx_int_t format)
+{
+    ngx_uint_t                                 nb, nsc, n;
+    ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+
+    if (format != NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) {
+        /*
+         * json/jsonp: once for the node itself and once more for the
+         * filterZones group the node belongs to.
+         */
+        return 2;
+    }
+
+    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    nb = (vtscf->histogram_buckets != NULL) ? vtscf->histogram_buckets->nelts : 0;
+    nsc = (ctx->measure_status_codes != NULL) ? ctx->measure_status_codes->nelts + 1 : 0;
+
+    /*
+     * Number of metric lines a single node emits, each of them carrying the
+     * name of the node at most once (the label pairs of the filterZones and
+     * upstreamZones lines are disjoint substrings of the same key):
+     *
+     *     serverZone   : 9 + 8 (cache) + status codes + (histogram + 3)
+     *     filterZone   : 9 + 8 (cache) + (histogram + 3)
+     *     upstreamZone : 11 + 2 * (histogram + 3)
+     *     cacheZone    : 12
+     */
+    n = 17 + nsc;
+
+    if (nb) {
+        n += 2 * (nb + 3);
+    }
+
+    return n;
+}
+
+
+/*
+ * Returns the size of the output of a single node, name excluded.
+ */
+static size_t
+ngx_http_vhost_traffic_status_display_node_fixed_size(ngx_http_request_t *r,
+    ngx_int_t format)
+{
+    ngx_uint_t                                 nb, nsc;
+    ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+
+    if (format == NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) {
+        return ngx_http_vhost_traffic_status_display_node_name_repeat(r, format)
+               * NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_PROMETHEUS_LINE;
+    }
+
+    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    nb = (vtscf->histogram_buckets != NULL) ? vtscf->histogram_buckets->nelts : 0;
+    nsc = (ctx->measure_status_codes != NULL) ? ctx->measure_status_codes->nelts + 1 : 0;
+
+    /* json/jsonp: the numeric payload of one node */
+    return 4 * NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_QUEUE_LEN
+             * (NGX_ATOMIC_T_LEN + 1)                    /* time queues       */
+           + 4 * nb * (NGX_ATOMIC_T_LEN + 1)             /* histogram buckets */
+           + 64 * (NGX_ATOMIC_T_LEN + 1)                 /* counters          */
+           + nsc * (NGX_ATOMIC_T_LEN + sizeof(",\"999\":") - 1)  /* statusCodes */
+           + 1024;                                       /* literal text      */
+}
+
+
+/*
+ * Returns the size that a node whose name is `name_len` bytes long takes in
+ * the output. `name_len` is the length of the name *after* escaping.
+ */
+size_t
+ngx_http_vhost_traffic_status_display_node_size(ngx_http_request_t *r,
+    size_t name_len, ngx_int_t format)
+{
+    return ngx_http_vhost_traffic_status_display_node_fixed_size(r, format)
+           + name_len
+             * ngx_http_vhost_traffic_status_display_node_name_repeat(r, format);
+}
+
+
+/*
+ * Returns NGX_OK if the node whose name is `name_len` bytes long still fits
+ * into the display buffer. The display handlers size the buffer with
+ * ngx_http_vhost_traffic_status_display_get_size(), so this is a safety net
+ * against that accounting ever getting out of sync with the writers: the
+ * caller must skip the node instead of writing past the end of the buffer.
+ */
+ngx_int_t
+ngx_http_vhost_traffic_status_display_buffer_check(ngx_http_request_t *r,
+    u_char *buf, size_t name_len, ngx_int_t format)
+{
+    size_t                                     need;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    /* not called from a display handler */
+    if (vtscf->display_buf_end == NULL) {
+        return NGX_OK;
+    }
+
+    need = ngx_http_vhost_traffic_status_display_node_size(r, name_len, format);
+
+    if (buf <= vtscf->display_buf_end
+        && (size_t) (vtscf->display_buf_end - buf) >= need)
+    {
+        return NGX_OK;
+    }
+
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                  "display_buffer_check::not enough buffer: "
+                  "left[%z], need[%uz], name[%uz], format[%i]",
+                  (ssize_t) (vtscf->display_buf_end - buf), need, name_len,
+                  format);
+
+    return NGX_ERROR;
+}
+
+
+static void
+ngx_http_vhost_traffic_status_display_get_size_node(ngx_http_request_t *r,
+    ngx_rbtree_node_t *node, ngx_int_t format, size_t *size)
+{
+    size_t                                 len;
+    ngx_http_vhost_traffic_status_ctx_t   *ctx;
+    ngx_http_vhost_traffic_status_node_t  *vtsn;
+
+    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+
+    if (node == ctx->rbtree->sentinel) {
+        return;
+    }
+
+    vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+
+    if (format == NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) {
+        len = ngx_http_vhost_traffic_status_escape_prometheus_len(vtsn->data,
+                                                                  vtsn->len);
+    } else {
+        len = ngx_http_vhost_traffic_status_escape_json_len(vtsn->data,
+                                                            vtsn->len);
+    }
+
+    *size += ngx_http_vhost_traffic_status_display_node_size(r, len, format);
+
+    ngx_http_vhost_traffic_status_display_get_size_node(r, node->left, format, size);
+    ngx_http_vhost_traffic_status_display_get_size_node(r, node->right, format, size);
+}
+
+
 ngx_int_t
 ngx_http_vhost_traffic_status_display_get_size(ngx_http_request_t *r,
     ngx_int_t format)
 {
-    ngx_uint_t                                 size, un;
+    size_t                                     size;
+    ngx_uint_t                                 un;
     ngx_slab_pool_t                           *shpool;
+    ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
     ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
 
+    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
     vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
     shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
 
@@ -589,44 +770,63 @@ ngx_http_vhost_traffic_status_display_get_size(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+    size = 0;
+
+    switch (format) {
+
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_HTML:
+        return sizeof(NGX_HTTP_VHOST_TRAFFIC_STATUS_HTML_DATA) + ngx_pagesize;
+
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSONP:
+        size += vtscf->jsonp.len + sizeof("()") - 1;
+        break;
+
+    default:
+        break;
+    }
+
     /* Caveat: Do not use duplicate ngx_shmtx_lock() before this function. */
     ngx_shmtx_lock(&shpool->mutex);
 
     ngx_http_vhost_traffic_status_shm_info(r, shm_info);
 
+    /*
+     * The names of the nodes are taken from the request (Host header, the
+     * variables of vhost_traffic_status_filter_by_set_key, ...) and are not
+     * length limited, so the size of the output has to be derived from the
+     * keys actually stored in the shared memory rather than from a fixed
+     * per node allowance.
+     */
+    ngx_http_vhost_traffic_status_display_get_size_node(r, ctx->rbtree->root,
+                                                        format, &size);
+
     ngx_shmtx_unlock(&shpool->mutex);
 
+    /* the "*" summary node of the serverZones */
+    size += ngx_http_vhost_traffic_status_display_node_size(r,
+                vtscf->sum_key.len * NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_JSON_ESCAPE,
+                format);
+
     /* allocate memory for the upstream groups even if upstream node not exists */
-    un = shm_info->used_node
-         + (ngx_uint_t) ngx_http_vhost_traffic_status_display_get_upstream_nelts(r);
+    un = (ngx_uint_t) ngx_http_vhost_traffic_status_display_get_upstream_nelts(r);
 
-    size = 0;
+    size += un * ngx_http_vhost_traffic_status_display_node_size(r,
+                     NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_CONF_NAME_LEN, format);
 
-    switch (format) {
+    /* main, connections, sharedZones and the section headers */
+    size += NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_MAIN_LEN;
 
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON:
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSONP:
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS:
-        size = sizeof(ngx_http_vhost_traffic_status_node_t) / NGX_PTR_SIZE
-               * NGX_ATOMIC_T_LEN * un  /* values size */
-               + (un * 1024)            /* names  size */
-               + 4096;                  /* main   size */
-        break;
-
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_HTML:
-        size = sizeof(NGX_HTTP_VHOST_TRAFFIC_STATUS_HTML_DATA) + ngx_pagesize;
-        break;
-    }
-
-    if (size <= 0) {
-        size = shm_info->max_size;
+    if (size > (size_t) NGX_MAX_INT_T_VALUE) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "display_get_size::size[%uz] too large", size);
+        return NGX_ERROR;
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "vts::display_get_size(): size[%ui] used_size[%ui], used_node[%ui]",
+                   "vts::display_get_size(): size[%uz] used_size[%ui], used_node[%ui]",
                    size, shm_info->used_size, shm_info->used_node);
 
-    return size;
+    return (ngx_int_t) size;
 }
 
 
@@ -643,7 +843,8 @@ ngx_http_vhost_traffic_status_display_get_time_queue(
         return (u_char *) "";
     }
 
-    p = ngx_pcalloc(r->pool, q->len * NGX_INT_T_LEN);
+    /* NGX_ATOMIC_T_LEN digits and the ',' separator per entry */
+    p = ngx_pcalloc(r->pool, q->len * (NGX_ATOMIC_T_LEN + 1));
     if (p == NULL) {
         return (u_char *) "";
     }
@@ -699,7 +900,8 @@ ngx_http_vhost_traffic_status_display_get_histogram_bucket(
         return (u_char *) "";
     }
 
-    p = ngx_pcalloc(r->pool, n * NGX_INT_T_LEN);
+    /* NGX_ATOMIC_T_LEN digits and the ',' separator per bucket */
+    p = ngx_pcalloc(r->pool, n * (NGX_ATOMIC_T_LEN + 1));
     if (p == NULL) {
         return (u_char *) "";
     }

--- a/src/ngx_http_vhost_traffic_status_display.h
+++ b/src/ngx_http_vhost_traffic_status_display.h
@@ -8,10 +8,31 @@
 #define _NGX_HTTP_VTS_DISPLAY_H_INCLUDED_
 
 
+/*
+ * Size of the main/connections/sharedZones part and of the section headers.
+ * The prometheus HELP/TYPE headers alone are slightly above 4k.
+ */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_MAIN_LEN         8192
+
+/* assumed length of the names that come from the configuration */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_CONF_NAME_LEN    1024
+
+/* upper bound of one prometheus line without the node name */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_PROMETHEUS_LINE  128
+
+/* worst case expansion of ngx_http_vhost_traffic_status_escape_json_pool() */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_DISPLAY_JSON_ESCAPE      6
+
+
 ngx_int_t ngx_http_vhost_traffic_status_display_get_upstream_nelts(
     ngx_http_request_t *r);
 ngx_int_t ngx_http_vhost_traffic_status_display_get_size(
     ngx_http_request_t *r, ngx_int_t format);
+
+size_t ngx_http_vhost_traffic_status_display_node_size(ngx_http_request_t *r,
+    size_t name_len, ngx_int_t format);
+ngx_int_t ngx_http_vhost_traffic_status_display_buffer_check(
+    ngx_http_request_t *r, u_char *buf, size_t name_len, ngx_int_t format);
 
 u_char *ngx_http_vhost_traffic_status_display_get_time_queue(
     ngx_http_request_t *r,

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -95,6 +95,12 @@ ngx_http_vhost_traffic_status_display_set_server_node(
                       "display_set_server_node::escape_json_pool() failed");
     }
 
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, dst.len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON) != NGX_OK)
+    {
+        return buf;
+    }
+
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_SERVER_START,
         &dst, vtsn->stat_request_counter,
         vtsn->stat_in_bytes,
@@ -316,6 +322,7 @@ u_char *
 ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
     u_char *buf, ngx_rbtree_node_t *node)
 {
+    u_char                                       *o, *s;
     ngx_str_t                                     key, filter;
     ngx_uint_t                                    i, j, n, rc;
     ngx_array_t                                  *filter_keys, *filter_nodes;
@@ -357,13 +364,31 @@ ngx_http_vhost_traffic_status_display_set_filter(ngx_http_request_t *r,
                                   "display_set_filter::escape_json_pool() failed");
                 }
 
+                if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf,
+                        filter.len, NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON)
+                    != NGX_OK)
+                {
+                    break;
+                }
+
+                o = buf;
+
                 buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_OBJECT_S,
                                   &filter);
+
+                s = buf;
 
                 nodes = filter_nodes->elts;
                 for (j = 0; j < filter_nodes->nelts; j++) {
                     buf = ngx_http_vhost_traffic_status_display_set_filter_node(r, buf,
                               nodes[j].node);
+                }
+
+                /* all the nodes of this group have been skipped */
+                if (s == buf) {
+                    buf = o;
+                    filter_nodes = NULL;
+                    continue;
                 }
 
                 buf--;
@@ -414,6 +439,12 @@ ngx_http_vhost_traffic_status_display_set_upstream_node(ngx_http_request_t *r,
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "display_set_upstream_node::escape_json_pool() failed");
+    }
+
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, key.len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON) != NGX_OK)
+    {
+        return buf;
     }
 
     if (vtsn != NULL) {
@@ -765,6 +796,12 @@ u_char
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "display_set_cache_node::escape_json_pool() failed");
+    }
+
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, key.len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_JSON) != NGX_OK)
+    {
+        return buf;
     }
 
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_CACHE,

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -6,6 +6,7 @@
 
 #include "ngx_http_vhost_traffic_status_module.h"
 #include "ngx_http_vhost_traffic_status_shm.h"
+#include "ngx_http_vhost_traffic_status_display.h"
 #include "ngx_http_vhost_traffic_status_display_prometheus.h"
 
 
@@ -63,6 +64,12 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server_node(
     server = *key;
 
     (void) ngx_http_vhost_traffic_status_node_position_key(&server, 1);
+
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, key->len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) != NGX_OK)
+    {
+        return buf;
+    }
 
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER,
                       &server, vtsn->stat_in_bytes,
@@ -227,6 +234,12 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(
     (void) ngx_http_vhost_traffic_status_node_position_key(&filter, 1);
     (void) ngx_http_vhost_traffic_status_node_position_key(&filter_name, 2);
 
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, key->len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) != NGX_OK)
+    {
+        return buf;
+    }
+
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER,
                       &filter, &filter_name, vtsn->stat_in_bytes,
                       &filter, &filter_name, vtsn->stat_out_bytes,
@@ -341,6 +354,13 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
         (void) ngx_http_vhost_traffic_status_node_position_key(&upstream_server, 1);
     }
 
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf,
+            key->len + sizeof("::nogroups") - 1,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) != NGX_OK)
+    {
+        return buf;
+    }
+
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM,
                       &upstream, &upstream_server, vtsn->stat_in_bytes,
                       &upstream, &upstream_server, vtsn->stat_out_bytes,
@@ -451,6 +471,12 @@ ngx_http_vhost_traffic_status_display_prometheus_set_cache_node(
     cache = *key;
 
     (void) ngx_http_vhost_traffic_status_node_position_key(&cache, 1);
+
+    if (ngx_http_vhost_traffic_status_display_buffer_check(r, buf, key->len,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_FORMAT_PROMETHEUS) != NGX_OK)
+    {
+        return buf;
+    }
 
     buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_CACHE,
                       &cache, vtsn->stat_cache_max_size,

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -295,6 +295,15 @@ typedef struct {
     ngx_array_t                            *limit_filter_traffics;
 
     ngx_http_vhost_traffic_status_node_t    stats;
+
+    /*
+     * End of the response buffer currently being filled by the display
+     * handlers. It is set right after the buffer is created and is used by
+     * ngx_http_vhost_traffic_status_display_buffer_check() to make sure that
+     * a node never writes past the end of the buffer.
+     */
+    u_char                                 *display_buf_end;
+
     ngx_msec_t                              start_msec;
     ngx_flag_t                              format;
     ngx_str_t                               jsonp;

--- a/src/ngx_http_vhost_traffic_status_string.c
+++ b/src/ngx_http_vhost_traffic_status_string.c
@@ -74,8 +74,13 @@ ngx_http_vhost_traffic_status_escape_json_pool(ngx_pool_t *pool,
 {
     u_char  *p;
 
-    buf->len = dst->len * 6;
-    buf->data = ngx_pcalloc(pool, buf->len);
+    /*
+     * The escaped string is not always NUL terminated by the escaping itself,
+     * so one extra byte is allocated for the terminator and the length is
+     * taken from the returned pointer instead of ngx_strlen().
+     */
+    buf->len = ngx_http_vhost_traffic_status_escape_json_len(dst->data, dst->len);
+    buf->data = ngx_pcalloc(pool, buf->len + 1);
     if (buf->data == NULL) {
         *buf = *dst;
         return NGX_ERROR;
@@ -89,9 +94,24 @@ ngx_http_vhost_traffic_status_escape_json_pool(ngx_pool_t *pool,
     p = (u_char *) ngx_escape_json(p, dst->data, dst->len);
 #endif
 
-    buf->len = ngx_strlen(buf->data);
+    buf->len = (size_t) (p - buf->data);
 
     return NGX_OK;
+}
+
+
+/*
+ * Returns the length that the string takes once escaped by
+ * ngx_http_vhost_traffic_status_escape_json_pool(), without allocating.
+ */
+size_t
+ngx_http_vhost_traffic_status_escape_json_len(u_char *p, size_t n)
+{
+#if !defined(nginx_version) || nginx_version < 1007009
+    return n + (size_t) ngx_http_vhost_traffic_status_escape_json(NULL, p, n);
+#else
+    return n + (size_t) ngx_escape_json(NULL, p, n);
+#endif
 }
 
 
@@ -164,6 +184,51 @@ ngx_http_vhost_traffic_status_replace_strc(ngx_str_t *buf,
     *(buf->data + buf->len) = '\0';
 
     return NGX_OK;
+}
+
+
+/*
+ * Returns the length that the string takes once escaped by
+ * ngx_http_vhost_traffic_status_escape_prometheus(), without allocating.
+ * It must stay in sync with the escaping loop below.
+ */
+size_t
+ngx_http_vhost_traffic_status_escape_prometheus_len(u_char *p, size_t n)
+{
+    u_char  *pa, *last, *char_end;
+    size_t   size;
+
+    last = p + n;
+    pa = p;
+    size = 0;
+
+    while (pa < last) {
+        if (isascii(*pa)) {
+            if (*pa == '"' || *pa == '\\' || *pa == '\n') {
+                /* "\\" + the character itself */
+                size += 2;
+
+            } else {
+                size += 1;
+            }
+
+            pa++;
+
+        } else {
+            char_end = pa;
+            if (*pa >= 0xf8 || ngx_utf8_decode(&char_end, last - pa) > 0x10ffff) {
+                /* invalid UTF-8 - escaped as "\\\\xHH" */
+                size += 5;
+                pa++;
+
+            } else {
+                size += (size_t) (char_end - pa);
+                pa = char_end;
+            }
+        }
+    }
+
+    return size;
 }
 
 

--- a/src/ngx_http_vhost_traffic_status_string.h
+++ b/src/ngx_http_vhost_traffic_status_string.h
@@ -22,6 +22,9 @@ ngx_int_t ngx_http_vhost_traffic_status_replace_strc(ngx_str_t *buf,
 ngx_int_t ngx_http_vhost_traffic_status_escape_prometheus(ngx_pool_t *pool, ngx_str_t *buf,
 	u_char *p, size_t n);
 
+size_t ngx_http_vhost_traffic_status_escape_json_len(u_char *p, size_t n);
+size_t ngx_http_vhost_traffic_status_escape_prometheus_len(u_char *p, size_t n);
+
 #endif /* _NGX_HTTP_VTS_STRING_H_INCLUDED_ */
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/t/026.long_names.t
+++ b/t/026.long_names.t
@@ -1,0 +1,200 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The names of the nodes come from the request (Host header, the variables of
+# vhost_traffic_status_filter_by_set_key, ...) and are not length limited, so
+# the display buffer has to be sized from the keys that are actually stored.
+# These tests feed oversized and hostile names and ask for every output format.
+# They are most useful when nginx is built with -fsanitize=address.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * blocks() * 4;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: long filter name, prometheus
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 8000)
+--- request eval
+['GET /probe', 'GET /status/format/prometheus']
+--- response_body_like eval
+['OK', 'nginx_vts_filter_bytes_total']
+
+
+
+=== TEST 2: long filter name, json
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 8000)
+--- request eval
+['GET /probe', 'GET /status/format/json']
+--- response_body_like eval
+['OK', 'filterZones']
+
+
+
+=== TEST 3: invalid utf-8 filter name, prometheus
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("\xff" x 4000)
+--- request eval
+['GET /probe', 'GET /status/format/prometheus']
+--- response_body_like eval
+['OK', 'nginx_vts_filter_bytes_total']
+
+
+
+=== TEST 4: control characters in filter name, json
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("\x01" x 4000)
+--- request eval
+['GET /probe', 'GET /status/format/json']
+--- response_body_like eval
+['OK', 'filterZones']
+
+
+
+=== TEST 5: several long names at once, prometheus
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        vhost_traffic_status_filter_by_set_key $http_x_test xt::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 6000) . "\nX-Test: " . ("B" x 6000)
+--- request eval
+['GET /probe', 'GET /status/format/prometheus']
+--- response_body_like eval
+['OK', 'nginx_vts_filter_bytes_total']
+
+
+
+=== TEST 6: long name with histogram and status codes, prometheus
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+    vhost_traffic_status_histogram_buckets 0.005 0.01 0.05 0.1 0.5 1 5 10;
+    vhost_traffic_status_measure_status_codes 200 404 500;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 8000)
+--- request eval
+['GET /probe', 'GET /status/format/prometheus']
+--- response_body_like eval
+['OK', 'nginx_vts_filter_bytes_total']
+
+
+
+=== TEST 7: long name through the control handler
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 8000)
+--- request eval
+['GET /probe', 'GET /status/control?cmd=status&group=filter&zone=*']
+--- response_body_like eval
+['OK', 'filterZones|\{\}']
+
+
+
+=== TEST 8: long name, html
+--- http_config
+    large_client_header_buffers 4 16k;
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format html;
+        access_log off;
+    }
+    location /probe {
+        vhost_traffic_status_filter_by_set_key $http_user_agent ua::$server_name;
+        return 200 "OK";
+    }
+--- more_headers eval
+"User-Agent: " . ("A" x 8000)
+--- request eval
+['GET /probe', 'GET /status/format/html']
+--- response_body_like eval
+['OK', 'vhost traffic status monitor']


### PR DESCRIPTION
## Problem

The display buffer is sized on the assumption that a single node never needs
more than 1024 bytes for its name:

```c
size = sizeof(ngx_http_vhost_traffic_status_node_t) / NGX_PTR_SIZE
       * NGX_ATOMIC_T_LEN * un  /* values size */
       + (un * 1024)            /* names  size */
       + 4096;                  /* main   size */
```

Node names are not length limited, though. They are taken from the request:
the `Host` header when `vhost_traffic_status_filter_by_host on` is used, or any
variable given to `vhost_traffic_status_filter_by_set_key` (`$http_user_agent`,
`$uri`, ...), so a client controls them up to `large_client_header_buffers`
(8k by default).

The prometheus writer then prints that name once per metric line, 17 times per
node for a serverZone or filterZone (9 + 8 cache lines), plus one line per
histogram bucket and one per measured status code. None of the JSON, JSONP or
prometheus writers check the remaining space before `ngx_sprintf()` - only the
HTML branch does.

With a single request carrying an 8000 byte `User-Agent` and a config such as

```nginx
vhost_traffic_status_filter_by_set_key $http_user_agent agent::*;
```

the next scrape of `/status/format/prometheus` writes about 136 KB into a
13.9 KB buffer:

```
==14937==ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8000 at 0x000109205e98
    #4 ngx_http_vhost_traffic_status_display_prometheus_set_filter_node ...:230
    #7 ngx_http_vhost_traffic_status_display_prometheus_set ...:552
0x000109205e98 is located 0 bytes after 23704-byte region
[alert] worker process 14937 exited on signal 6
```

The attacker does not need access to the status endpoint: they only have to
send the long header to the public site, the corruption happens when the
monitoring system scrapes the status page. `/format/prometheus` can also be
selected from the URI, so a JSON configured endpoint is affected as well.

While verifying the fix a second overflow showed up in the same path.
`escape_json_pool()` allocates exactly `len * 6` bytes, which the escaping
fills completely when every byte expands to `\u00XX`, leaving no room for the
terminator that `ngx_strlen()` then looks for. The length that comes back is
whatever the adjacent heap happens to contain, and it is used as the `%V`
length, so it also leaks heap memory into the status page.

## Changes

**Size the buffer from the keys that are actually stored** - `display_get_size()`
walks the rbtree and sums the real, post escape length of every key. The
per node cost is `fixed + name_len * repeat`, where `repeat` is derived from
the configuration (number of metric lines for prometheus, 2 for JSON: the node
itself and its filterZones group heading). Two helpers,
`escape_json_len()` and `escape_prometheus_len()`, measure the escaped length
without allocating.

**Check the remaining space before writing a node** -
`display_buffer_check()` compares the space left in the buffer against what the
node needs and makes the caller skip the node and log an error instead of
writing past the end. This is a safety net: if the accounting above ever drifts
from the writers, the output is truncated rather than the heap corrupted. The
JSON filterZones group is rolled back as a whole when all of its nodes are
skipped, so the output stays structurally valid.

**Fix `escape_json_pool()`** - allocate the exact escaped length plus one byte
and take the length from the returned pointer instead of `ngx_strlen()`.

**Fix the time queue and histogram string buffers** - they allocated
`n * NGX_INT_T_LEN` but write up to `NGX_ATOMIC_T_LEN + 1` bytes per entry,
the separator was not accounted for.

## Tests

`t/026.long_names.t` feeds oversized and hostile names through every output
format: 8000 byte names, invalid UTF-8 (worst case for the prometheus
escaping), control characters (worst case for the JSON escaping), several large
nodes at once, and the same with histogram buckets and measured status codes
enabled, plus the control handler and the HTML page.

A new `asan` CI job builds nginx with `-fsanitize=address` and runs the suite
under it. ASan reports are collected with `log_path` and checked in a separate
step that always runs, so a memory error fails the build even if the test
itself happens to pass.

Verified with nginx 1.28.0:

| build | `t/026.long_names.t` | ASan reports |
| --- | --- | --- |
| before | 4 cases fail | 5 heap-buffer-overflow |
| after | pass | none |

No regressions: all 26 test files give identical results before and after, both
in a normal build and under ASan, and the JSON and prometheus output for
ordinary traffic is byte for byte identical.

## Note on memory use

Long names are now allocated for correctly instead of overflowing, so a node
with an 8000 byte key legitimately produces a ~720 KB prometheus response. That
is the real size of the output for such a node, but it means large keys are
expensive to render. Capping the key length when a node is created (the dump
restore path already ignores keys above 1024 bytes) would be a good follow up.
