### PR TITLE
ci: build with and without the HTTP cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,34 @@ jobs:
         if: failure()
         working-directory: nginx-module-vts
         run: sudo tail -n 100 t/servroot/logs/error.log || true
+
+  build-variants:
+    name: 'build (${{ matrix.variant.name }})'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          # NGX_HTTP_CACHE guards a fair amount of the module, both states
+          # have to compile
+          - name: 'with cache'
+            opts: ''
+          - name: 'without cache'
+            opts: '--without-http-cache'
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: nginx-module-vts
+      - name: 'checkout nginx'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: nginx/nginx
+          path: nginx
+          ref: 'a92a537860c7b87d3793d9eb41c9cf3ed833b53c'
+      - name: 'build nginx'
+        working-directory: nginx
+        run: |
+          ./auto/configure ${{ matrix.variant.opts }} \
+            --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts
+          make -j$(nproc)


### PR DESCRIPTION
## Problem

A fair amount of the module sits behind `#if (NGX_HTTP_CACHE)`: the cache
counters on the node, `shm_add_cache()`, the cache zones in all three output
formats. CI only ever builds the default configuration, where the cache is
enabled, so nothing compiles the other half of those conditionals.

That gap is not theoretical. #344 currently fails to build as soon as nginx is
configured without the cache, because a variable is declared outside the
`#if (NGX_HTTP_CACHE)` block that uses it, and nginx compiles add-on modules
with `-Werror`:

```
$ ./auto/configure --without-http-cache --add-module=/path/to/nginx-module-vts && make
src/ngx_http_vhost_traffic_status_shm.c:93:48: error: unused variable 'rc' [-Werror,-Wunused-variable]
```

It took a manual build to notice.

## Change

A `build-variants` job that compiles the module twice, with and without the
HTTP cache. It is build only: the test suite is already covered by the existing
`build` job, and several tests assert on cache fields that do not exist in a
build without the cache.

The two matrix entries appear as `build (with cache)` and
`build (without cache)`.

Both variants were built locally against current master, with the default
module set: no errors, no warnings.

## Note

If required status checks are enabled on master later on, these two names have
to be added to the list alongside `build` and `asan`. Required checks are
matched by name, so a job that is renamed or a matrix entry that is added stays
"pending" forever until the list is updated. If that becomes a nuisance, a
single aggregating job that `needs:` all the others would keep the required
list down to one entry.
