### PR TITLE
ci: turn on UndefinedBehaviorSanitizer as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,12 @@ jobs:
         run: |
           # -fno-sanitize-recover makes undefined behaviour abort the worker
           # instead of printing and carrying on, so the test that reached it
-          # fails
+          # fails. nonnull-attribute is left out: ngx_pstrdup() hands the null
+          # data pointer of an empty string to ngx_memcpy() on every start
           ./auto/configure \
             --prefix=/usr/local/nginx-asan \
             --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \
-            --with-cc-opt="-fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+            --with-cc-opt="-fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
             --with-ld-opt="-fsanitize=address,undefined"
           make -j$(nproc)
           sudo make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,12 @@ jobs:
         run: |
           # -fno-sanitize-recover makes undefined behaviour abort the worker
           # instead of printing and carrying on, so the test that reached it
-          # fails. nonnull-attribute is left out: ngx_pstrdup() hands the null
-          # data pointer of an empty string to ngx_memcpy() on every start
+          # fails. nonnull-attribute is left out: ngx_pstrdup() hands the
+          # null data pointer of an empty conf_param to ngx_memcpy() on every
+          # start of nginx. Fixed upstream by b0a4d0fb82 and released in the
+          # mainline 1.31.0, the stable branch does not carry it, 1.30.4
+          # included, so the check stays out while the tests build a stable
+          # release
           ./auto/configure \
             --prefix=/usr/local/nginx-asan \
             --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,18 +149,21 @@ jobs:
         # the sanitizer runtime cannot map its shadow memory with the high
         # entropy ASLR of the ubuntu-24.04 kernel
         run: sudo sysctl -w vm.mmap_rnd_bits=28 || true
-      - name: 'build nginx with AddressSanitizer'
+      - name: 'build nginx with the sanitizers'
         working-directory: nginx
         run: |
+          # -fno-sanitize-recover makes undefined behaviour abort the worker
+          # instead of printing and carrying on, so the test that reached it
+          # fails
           ./auto/configure \
             --prefix=/usr/local/nginx-asan \
             --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \
-            --with-cc-opt="-fsanitize=address -fno-omit-frame-pointer -g -O1" \
-            --with-ld-opt="-fsanitize=address"
+            --with-cc-opt="-fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+            --with-ld-opt="-fsanitize=address,undefined"
           make -j$(nproc)
           sudo make install
           /usr/local/nginx-asan/sbin/nginx -V
-      - name: 'test under AddressSanitizer'
+      - name: 'test under the sanitizers'
         working-directory: nginx-module-vts
         run: |
           # the nginx workers drop privileges, so they need to be able to
@@ -168,16 +171,17 @@ jobs:
           sudo mkdir -p /tmp/asan && sudo chmod 777 /tmp/asan
           # the lua tests need modules that are not part of this build
           sudo ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:disable_coredump=1:log_path=/tmp/asan/vts \
+               UBSAN_OPTIONS=print_stacktrace=1:log_path=/tmp/asan/vts \
                PATH=/usr/local/nginx-asan/sbin:$PATH prove $(ls t/*.t | grep -v '_by_lua')
-      - name: 'check AddressSanitizer reports'
+      - name: 'check the sanitizer reports'
         if: always()
         run: |
           if compgen -G '/tmp/asan/vts.*' > /dev/null; then
-            echo '::error::AddressSanitizer reported memory errors'
+            echo '::error::the sanitizers reported errors'
             cat /tmp/asan/vts.*
             exit 1
           fi
-          echo 'no AddressSanitizer reports'
+          echo 'no sanitizer reports'
       - name: 'dump nginx error log'
         if: failure()
         working-directory: nginx-module-vts


### PR DESCRIPTION
The sanitizer job builds with AddressSanitizer, which finds memory errors and
nothing else. Undefined behaviour of the arithmetic kind goes through it
unnoticed.

That came up while reviewing #353: a lockless read of the time queue could see
a length of zero and the averaging loop takes an index modulo that length.
AddressSanitizer says nothing about it, and neither does the clang static
analyzer, which was tried on the code. Worse, without a sanitizer the two
architectures disagree:

| | integer division by zero |
| --- | --- |
| x86-64 | `idiv` traps, the worker dies with SIGFPE |
| arm64 | `sdiv` returns zero, the module carries on with a wrong value |

So the same defect is a crash on one machine and a silently wrong statistic on
another. With `-fsanitize=undefined` it is neither:

```
runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ...
```

`-fno-sanitize-recover=undefined` makes it abort rather than print and carry
on, so the test that reached it fails instead of passing with a warning
buried in the log. `UBSAN_OPTIONS` writes to the same place as
`ASAN_OPTIONS`, so the step that already looks for reports covers both.

Checked locally with nginx 1.28.0: the two sanitizers build together without
complaint and the suite gives the same results as before, no reports.

This does not make the job find races on its own, it only makes sure that
undefined behaviour is loud on the paths the tests do reach.
