### PR TITLE
Fix the control interface for upstream peers that are not the first address

### DIFF
--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -44,7 +44,7 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
 {
     ngx_int_t                       rc;
     ngx_str_t                       key, usg, ush;
-    ngx_uint_t                      i, j;
+    ngx_uint_t                      i, j, k;
     ngx_http_upstream_server_t     *us;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
@@ -99,17 +99,34 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
             if (ngx_strncmp(uscf->host.data, usg.data, usg.len) == 0) {
 
                 for (j = 0; j < uscf->servers->nelts; j++) {
-                    if (us[j].addrs->name.len == ush.len) {
-                        if (ngx_strncmp(us[j].addrs->name.data, ush.data, ush.len) == 0) {
-                            *usn = us[j];
+
+                    /* a server of a group resolves to one address per A record */
+
+                    for (k = 0; k < us[j].naddrs; k++) {
+                        if (us[j].addrs[k].name.len != ush.len) {
+                            continue;
+                        }
+
+                        if (ngx_strncmp(us[j].addrs[k].name.data, ush.data,
+                                        ush.len)
+                            != 0)
+                        {
+                            continue;
+                        }
+
+                        *usn = us[j];
 
 #if nginx_version > 1007001
-                            usn->name = us[j].addrs->name;
+                        usn->name = us[j].addrs[k].name;
 #endif
 
-                            control->count++;
-                            break;
-                        }
+                        control->count++;
+
+                        break;
+                    }
+
+                    if (control->count) {
+                        break;
                     }
                 }
 

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -100,7 +100,7 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
 
                 for (j = 0; j < uscf->servers->nelts; j++) {
 
-                    /* a server of a group resolves to one address per A record */
+                    /* a server gives one peer per address its name resolves to */
 
                     for (k = 0; k < us[j].naddrs; k++) {
                         if (us[j].addrs[k].name.len != ush.len) {

--- a/t/029.control_upstream_addrs.t
+++ b/t/029.control_upstream_addrs.t
@@ -10,12 +10,23 @@
 use Test::Nginx::Socket;
 
 use IO::Socket::IP;
-use Socket qw(getaddrinfo SOCK_STREAM);
+use Socket qw(getaddrinfo getnameinfo SOCK_STREAM NI_NUMERICHOST NIx_NOSERV);
+
+# The test asks for the two peers by name, so it needs the name to give
+# those two addresses and no others will do.
 
 my ($err, @addrs) = getaddrinfo('localhost', '', { socktype => SOCK_STREAM });
+my %resolved;
 
-plan skip_all => 'localhost resolves to one address only'
-    if $err or @addrs < 2;
+unless ($err) {
+    for my $addr (@addrs) {
+        my ($e, $host) = getnameinfo($addr->{addr}, NI_NUMERICHOST, NIx_NOSERV);
+        $resolved{$host} = 1 unless $e;
+    }
+}
+
+plan skip_all => 'localhost does not resolve to both loopback addresses'
+    if $err or not ($resolved{'127.0.0.1'} and $resolved{'::1'});
 
 plan skip_all => 'the IPv6 loopback is not usable'
     unless IO::Socket::IP->new(LocalHost => '::1', LocalPort => 0, Listen => 1);

--- a/t/029.control_upstream_addrs.t
+++ b/t/029.control_upstream_addrs.t
@@ -1,0 +1,63 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# A server of an upstream group resolves to one peer per address of its name.
+# The control handler has to find every one of them, not only the first, which
+# is what the display of the group does.
+#
+# The name used here is localhost, so the test needs it to resolve to both
+# loopback addresses and needs the IPv6 one to be usable.
+
+use Test::Nginx::Socket;
+
+use IO::Socket::IP;
+use Socket qw(getaddrinfo SOCK_STREAM);
+
+my ($err, @addrs) = getaddrinfo('localhost', '', { socktype => SOCK_STREAM });
+
+plan skip_all => 'localhost resolves to one address only'
+    if $err or @addrs < 2;
+
+plan skip_all => 'the IPv6 loopback is not usable'
+    unless IO::Socket::IP->new(LocalHost => '::1', LocalPort => 0, Listen => 1);
+
+plan tests => repeat_each() * blocks() * 8;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: the control handler finds every address of an upstream server
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream backend {
+        server localhost:1984;
+    }
+--- config
+    listen [::1]:1984;
+
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /up',
+    'GET /status/control?cmd=status&group=upstream%40group&zone=backend%40127.0.0.1%3A1984',
+    'GET /status/control?cmd=status&group=upstream%40group&zone=backend%40[%3A%3A1]%3A1984',
+]
+--- response_body_like eval
+[
+    'OK',
+    'OK',
+    qr/"server":"127\.0\.0\.1:1984"/,
+    qr/"server":"\[::1\]:1984"/,
+]


### PR DESCRIPTION
Fixes #259.

## Problem

A `server` line of an upstream group gives one peer per address its name
resolves to, and the module names those peers after the address:

```
upstream backend {
    server localhost:1984;      # 127.0.0.1:1984 and [::1]:1984
}
```

The display of the group walks all of them, `display_set_upstream_group()`
loops over `usn.naddrs` under a comment that says *for all A records*. The
control handler does not: `node_upstream_lookup()` compares the zone of the
request against `us[j].addrs->name`, which is the first address of the
server line and nothing else.

So `/status/format/json` lists both peers, while
`/status/control?cmd=status&group=upstream@group&zone=backend@...` answers
`{}` for whichever of them is not `addrs[0]`. Which peer is reachable
depends on the order the resolver returns, so the same configuration
behaves differently on two machines.

`vhost_traffic_status_set_by_filter` goes through the same lookup and
fails for those peers as well. `reset` and `delete` do not, they work off
the key of the tree, so they are unaffected.

## Test first

The first commit adds the test only, so the failure is on the record before
the change that fixes it. It proxies through such an upstream and asks the
control handler for both peers, expecting `"server"` of each in the answer.

The test needs a name that resolves to two addresses; it uses `localhost`
and skips where that gives a single address or where the IPv6 loopback
cannot be bound.

## Fix

The second commit walks the addresses of the server line the way the
display already does.

The loop is nested but the work is linear in the number of peers: the inner
count is `naddrs` of that server line, so the total is the number of
addresses of the group, which is the set that has to be searched to find a
peer by name. It ends early on a match, and it runs on the control
interface only, not on the request path.