### PR TITLE
Consult the filter cap only for an insertion it governs

### DIFF
--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -129,8 +129,10 @@ found:
 
 
 ngx_rbtree_node_t *
-ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r)
+ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
+    ngx_str_t *key)
 {
+    ngx_str_t                                  filter;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
@@ -140,6 +142,28 @@ ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r)
 
     /* disabled */
     if (ctx->filter_max_node == 0) {
+        return NULL;
+    }
+
+    /*
+     * The cap counts the nodes of the filter groups the directive names, so
+     * only an insertion into one of those groups can take it over. A server
+     * zone, an upstream peer, a cache or a filter of a group the directive
+     * does not name has nothing to do with it, and dropping a node for one
+     * of them loses a measurement while the zone still has room.
+     */
+
+    if (type != NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG) {
+        return NULL;
+    }
+
+    filter = *key;
+
+    if (ngx_http_vhost_traffic_status_node_position_key(&filter, 1) != NGX_OK) {
+        return NULL;
+    }
+
+    if (ngx_http_vhost_traffic_status_filter_max_node_match(r, &filter) != NGX_OK) {
         return NULL;
     }
 

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -197,7 +197,8 @@ void ngx_http_vhost_traffic_status_find_name(ngx_http_request_t *r,
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
     ngx_str_t *key, unsigned type, uint32_t key_hash);
 
-ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r);
+ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r,
+    unsigned type, ngx_str_t *key);
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru_node(ngx_http_request_t *r,
     ngx_rbtree_node_t *a, ngx_rbtree_node_t *b);
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru_node_cmp(ngx_http_request_t *r,

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -130,7 +130,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         init = NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_NONE;
 
         /* delete lru node */
-        lrun = ngx_http_vhost_traffic_status_find_lru(r);
+        lrun = ngx_http_vhost_traffic_status_find_lru(r, type, key);
         if (lrun != NULL) {
             ngx_rbtree_delete(ctx->rbtree, lrun);
             ngx_slab_free_locked(shpool, lrun);

--- a/t/032.filter_max_node_scope.t
+++ b/t/032.filter_max_node_scope.t
@@ -1,0 +1,116 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# vhost_traffic_status_filter_max_node caps the nodes of the filter groups it
+# names. The cap used to be consulted whenever any node was added, so an
+# insertion it does not govern dropped a node that was inside it, with room
+# left in the zone.
+#
+# TEST 1 adds a node of another kind: a set key with no group makes a server
+# node rather than a filter one. TEST 2 adds a filter of a group the directive
+# does not name. Neither may cost the capped group anything. TEST 3 is the
+# insertion the cap does govern, which still has to drop the oldest.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each(1) * blocks() * 8;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: a node of another kind does not drop one inside the cap
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 2 uris;
+    vhost_traffic_status_filter_by_set_key $uri uris::;
+    vhost_traffic_status_filter_by_set_key $request_method;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        vhost_traffic_status_bypass_stats on;
+        vhost_traffic_status_bypass_limit on;
+    }
+    location /f {
+        return 200 "ok\n";
+    }
+--- request eval
+[
+    'GET /f1',
+    'GET /f2',
+    'HEAD /f1',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'ok',
+    'ok',
+    '',
+    qr/"\/f2"/,
+]
+
+
+
+=== TEST 2: nor does a filter of a group the cap does not name
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 2 uris;
+    vhost_traffic_status_filter_by_set_key $uri uris::;
+    vhost_traffic_status_filter_by_set_key $request_method method::;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        vhost_traffic_status_bypass_stats on;
+        vhost_traffic_status_bypass_limit on;
+    }
+    location /f {
+        return 200 "ok\n";
+    }
+--- request eval
+[
+    'GET /f1',
+    'GET /f2',
+    'HEAD /f1',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'ok',
+    'ok',
+    '',
+    qr/"\/f2"/,
+]
+
+
+
+=== TEST 3: the cap still drops the oldest of the group it names
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 2 uris;
+    vhost_traffic_status_filter_by_set_key $uri uris::;
+    vhost_traffic_status_filter_by_set_key $request_method;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        vhost_traffic_status_bypass_stats on;
+        vhost_traffic_status_bypass_limit on;
+    }
+    location /f {
+        return 200 "ok\n";
+    }
+--- request eval
+[
+    'GET /f1',
+    'GET /f2',
+    'GET /f3',
+    'GET /status/format/json',
+]
+--- response_body_unlike eval
+[
+    qr/never matches the body of a request/,
+    qr/never matches the body of a request/,
+    qr/never matches the body of a request/,
+    qr/"\/f1"/,
+]


### PR DESCRIPTION
Part of #136.

## Problem

`vhost_traffic_status_filter_max_node` caps the nodes of the filter groups it
names. The cap is consulted whenever *any* node is added:

```c
    /* delete lru node */
    lrun = ngx_http_vhost_traffic_status_find_lru(r);
```

`find_lru()` then drops the least recently used node of the capped groups as
soon as they are at the cap, whatever kind of node prompted the call. So an
insertion the cap does not govern costs a measurement, while the zone still
has room for both.

Two shapes of it, with `vhost_traffic_status_filter_max_node 2 uris` and
`$uri` keyed into `uris::`:

| the third request adds | `uris::` before | after |
| --- | --- | --- |
| a node of another kind (a set key with no group makes a server node) | `/f1 /f2` | `/f1` |
| a filter of a group the directive does not name | `/f1 /f2` | `/f1` |
| a filter of the capped group | `/f1 /f2` | `/f2 /f3` |

Only the third row is the cap doing its job. The first two lose `/f2` for
nothing: the zone was nearly empty, and neither insertion belongs to the
group the directive limits.

It repeats. The capped group refills to the cap and the next unrelated
insertion knocks one out again, so its effective size is one below what was
asked for and its contents churn with traffic that has nothing to do with it.

## Fix

Give `find_lru()` the type and the key of the node being added, and leave the
tree alone unless that node belongs to a group the directive names.

The eviction the cap does govern is unchanged, which is what TEST 3 is for:
it passes before and after, so the fix cannot quietly turn the cap off.

## Test first

The first commit adds the tests on their own so the failure is on the record
before the change that fixes it. TEST 1 and TEST 2 fail on master, TEST 3
passes there and has to keep passing.

## Not this patch

This is one piece of #136. The report is about nodes never being freed for
upstreams that are gone, and that stands: nothing evicts a server, upstream
or cache node, and the filter cap is the only budget in the module. With a
name that resolves to a new address every second I measured the zone growing
monotonically until `shm_add_node::ngx_slab_alloc_locked() failed`, after
which no node of any kind is created any more — a new server zone stops
appearing in the output, with only the error log to say why. That needs a
decision about eviction or expiry across all node types, so it is left out
of here.
