### PR TITLE
Say how much of the shared zone is left

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ JSON document contains as follows:
         "name":...,
         "maxSize":...,
         "usedSize":...,
-        "usedNode":...
+        "usedNode":...,
+        "freeSize":...
     },
     "serverZones": {
         "...":{
@@ -674,6 +675,8 @@ The following status information is provided in the JSON format:
     * The current size of the shared memory.
   * usedNode
     * The current number of node using in shared memory. It can get an approximate size for one node with the following formula: (*usedSize* / *usedNode*)
+  * freeSize
+    * The room the shared memory has left for more nodes. *usedSize* above is the sum of the sizes of the nodes, which is not what the zone has spent, because the slab allocator hands out a whole page or a whole slot for each of them. A zone therefore stops accepting nodes while *usedSize* still reads below *maxSize*, and this is the value that says so. A node is larger than half a page, so where a page is 4k this is the room for more of them; where the page is larger it is a lower bound, since a partly used page can still hold one.
 * serverZones
   * requestCounter
     * The total number of client requests received from clients.

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -84,7 +84,8 @@ ngx_http_vhost_traffic_status_display_set_main(ngx_http_request_t *r,
                       ngx_http_vhost_traffic_status_current_msec(),
                       ac, rd, wr, wa, ap, hn, rq,
                       shm_info->name, shm_info->max_size,
-                      shm_info->used_size, shm_info->used_node);
+                      shm_info->used_size, shm_info->used_node,
+                      shm_info->free_size);
 
     return buf;
 }

--- a/src/ngx_http_vhost_traffic_status_display_json.h
+++ b/src/ngx_http_vhost_traffic_status_display_json.h
@@ -35,7 +35,8 @@
     "\"name\":\"%V\","                                                         \
     "\"maxSize\":%ui,"                                                         \
     "\"usedSize\":%ui,"                                                        \
-    "\"usedNode\":%ui"                                                         \
+    "\"usedNode\":%ui,"                                                        \
+    "\"freeSize\":%ui"                                                         \
     "},"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_SERVER_S "\"serverZones\":{"

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -40,7 +40,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_main(ngx_http_request_t *r,
                       (double) vtscf->start_msec / 1000,
                       ap, ac, hn, rd, rq, wa, wr,
                       shm_info->name, shm_info->max_size,
-                      shm_info->used_size, shm_info->used_node);
+                      shm_info->used_size, shm_info->used_node,
+                      shm_info->free_size);
 
     return buf;
 }

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -28,7 +28,8 @@
     "# TYPE nginx_vts_main_shm_usage_bytes gauge\n"                            \
     "nginx_vts_main_shm_usage_bytes{shared=\"max_size\"} %ui\n"                \
     "nginx_vts_main_shm_usage_bytes{shared=\"used_size\"} %ui\n"               \
-    "nginx_vts_main_shm_usage_bytes{shared=\"used_node\"} %ui\n"
+    "nginx_vts_main_shm_usage_bytes{shared=\"used_node\"} %ui\n"                \
+    "nginx_vts_main_shm_usage_bytes{shared=\"free_size\"} %ui\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_S                  \
     "# HELP nginx_vts_server_bytes_total The request/response bytes\n"         \

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -67,14 +67,31 @@ void
 ngx_http_vhost_traffic_status_shm_info(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_shm_info_t *shm_info)
 {
-    ngx_http_vhost_traffic_status_ctx_t  *ctx;
+    ngx_slab_pool_t                           *shpool;
+    ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
 
     ngx_memzero(shm_info, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
 
     shm_info->name = &ctx->shm_name;
     shm_info->max_size = ctx->shm_size;
+
+    /*
+     * used_size below is the sum of the sizes of the nodes, which is not what
+     * the zone has spent: the slab hands out a whole page or a whole slot for
+     * each of them. Ask the slab what it has left, so that the display says
+     * whether another node fits. A node is larger than half a page, so where
+     * a page is 4k this is the room for more of them; where it is larger the
+     * figure is a lower bound, since a partly used page can still hold one.
+     */
+
+    if (vtscf->shm_zone != NULL) {
+        shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
+        shm_info->free_size = shpool->pfree * ngx_pagesize;
+    }
 
     ngx_http_vhost_traffic_status_shm_info_node(r, shm_info, ctx->rbtree->root);
 }

--- a/src/ngx_http_vhost_traffic_status_shm.h
+++ b/src/ngx_http_vhost_traffic_status_shm.h
@@ -13,6 +13,7 @@ typedef struct {
     ngx_uint_t   max_size;
     ngx_uint_t   used_size;
     ngx_uint_t   used_node;
+    ngx_uint_t   free_size;
 
     ngx_uint_t   filter_used_size;
     ngx_uint_t   filter_used_node;

--- a/t/033.shm_free_size.t
+++ b/t/033.shm_free_size.t
@@ -1,0 +1,45 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# usedSize is the sum of the sizes of the nodes, which is not what the zone
+# has spent: the slab hands out a whole page or a whole slot for each of them.
+# A zone can therefore refuse a node while usedSize still reads well below
+# maxSize, and the only sign of it is a line in the error log.
+#
+# freeSize is what the slab itself has left, so that the display says whether
+# there is room.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each(2) * blocks() * 2;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: the shared zone says how much of it is left
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request
+GET /status/format/json
+--- response_body_like: "sharedZones":\{.*"freeSize":\d+
+
+
+
+=== TEST 2: and says it to prometheus as well
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+        access_log off;
+    }
+--- request
+GET /status/format/prometheus
+--- response_body_like: nginx_vts_main_shm_usage_bytes\{shared="free_size"\} \d+

--- a/t/validate_json_schema.py
+++ b/t/validate_json_schema.py
@@ -126,7 +126,7 @@ def validate(data):
 
     # sharedZones
     if "sharedZones" in data:
-        sz_keys = ["name", "maxSize", "usedSize", "usedNode"]
+        sz_keys = ["name", "maxSize", "usedSize", "usedNode", "freeSize"]
         errors.extend(check_keys(data["sharedZones"], sz_keys, "sharedZones"))
 
     # serverZones


### PR DESCRIPTION
Part of #136.

## Problem

`usedSize` is the sum of the sizes of the nodes:

```c
        size = offsetof(ngx_rbtree_node_t, color)
               + offsetof(ngx_http_vhost_traffic_status_node_t, data)
               + vtsn->len;

        shm_info->used_size += size;
```

That is not what the zone has spent. A node is about 3550 bytes, and the
slab hands out a whole page or a whole slot for it, so the zone runs out
while `usedSize` still reads well below `maxSize`. Filled with distinct
filter keys until the first refusal:

| zone | nodes it took | `usedSize` then | `maxSize` |
| --- | --- | --- | --- |
| 256k | 52 | 184581 (70%) | 262144 |
| 512k | 116 | 411797 (79%) | 524288 |
| 1m | 244 | 866325 (83%) | 1048576 |

Someone watching `usedSize` against `maxSize` sees a sixth of the zone free
at the moment it stops accepting nodes. And it stops accepting all of them,
not only the kind that filled it: after that point a request for a host that
has no node yet adds no server zone, so sites quietly go missing from the
output. The only sign is one line per attempt in the error log:

```
shm_add_node::ngx_slab_alloc_locked() failed: used_size[185211], used_node[52]
```

## Fix

Report what the slab has left, its free pages, in both formats:

```
"sharedZones":{ ..., "freeSize":114688 }
nginx_vts_main_shm_usage_bytes{shared="free_size"} 114688
```

On the same 256k zone it reaches zero exactly where the refusals begin:

| nodes | `usedSize` | `freeSize` | |
| --- | --- | --- | --- |
| 21 | 28% of max | 114688 | |
| 41 | 55% of max | 32768 | |
| 52 | 70% of max | **0** | refusals start here |

A node is larger than half a page, so on a 4k-page system the slab takes a
whole page for each one and this is exactly the room left for more. Where a
page is larger the figure is a lower bound, since a partly used page can
still hold another node.

`usedSize` keeps its meaning, which is the size of what is being measured
rather than the cost of holding it.

## Test first

The first commit adds the tests on their own. `t/033` asks both formats for
the field, and the JSON schema is made to require it, so `t/025` fails as
well until the field is there.

## Not this patch

This makes the exhaustion visible; it does not stop it. Nothing evicts a
server, upstream or cache node, and the filter cap is the only budget in the
module, so a group of upstreams whose addresses keep changing grows the zone
until it is full and stays there. That needs a decision about eviction or
expiry across all node types and is left out of here. #360 is a separate
piece of the same report.
