### PR TITLE
Read the tree of the shared memory under its mutex

### DIFF
--- a/src/ngx_http_vhost_traffic_status_set.c
+++ b/src/ngx_http_vhost_traffic_status_set.c
@@ -321,15 +321,27 @@ ngx_http_vhost_traffic_status_set_by_filter_node(
     ngx_http_vhost_traffic_status_control_t *control,
     ngx_str_t *buf)
 {
-    u_char                                *p;
-    ngx_int_t                              rc;
-    ngx_str_t                              key;
-    ngx_rbtree_node_t                     *node;
-    ngx_http_request_t                    *r;
-    ngx_http_upstream_server_t             us;
-    ngx_http_vhost_traffic_status_node_t  *vtsn;
+    u_char                                    *p;
+    ngx_int_t                                  rc;
+    ngx_str_t                                  key;
+    ngx_uint_t                                 found;
+    ngx_atomic_uint_t                          value;
+    ngx_slab_pool_t                           *shpool;
+    ngx_rbtree_node_t                         *node;
+    ngx_http_request_t                        *r;
+    ngx_http_upstream_server_t                 us;
+    ngx_http_vhost_traffic_status_node_t      *vtsn;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     r = control->r;
+
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+
+    if (vtscf->shm_zone == NULL) {
+        return NGX_ERROR;
+    }
+
+    shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
 
     rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, control->zone,
                                                          control->group);
@@ -340,13 +352,6 @@ ngx_http_vhost_traffic_status_set_by_filter_node(
         return NGX_ERROR;
     }
 
-    node = ngx_http_vhost_traffic_status_find_node(r, &key, control->group, 0);
-    if (node == NULL) {
-        return NGX_ERROR;
-    }
-
-    vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
-
     p = ngx_pnalloc(r->pool, NGX_ATOMIC_T_LEN);
     if (p == NULL) {
         return NGX_ERROR;
@@ -356,28 +361,62 @@ ngx_http_vhost_traffic_status_set_by_filter_node(
 
     ngx_memzero(&us, sizeof(ngx_http_upstream_server_t));
 
-    switch (control->group) {
+    /*
+     * Every other reader of the tree holds the mutex of the zone while it
+     * walks it and while it reads the node it found. This one did not, and a
+     * node can be taken out of the tree and handed back to the slab under it:
+     * by the eviction of vhost_traffic_status_filter_max_node, or by the
+     * delete command of the control handler.
+     */
 
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO:
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC:
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG:
-        buf->len = ngx_sprintf(p, "%uA", ngx_http_vhost_traffic_status_set_by_filter_node_member(
-                                             control, vtsn, &us)) - p;
-        break;
+    rc = NGX_OK;
+    found = 0;
+    value = 0;
 
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
-    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
-        ngx_http_vhost_traffic_status_node_upstream_lookup(control, &us);
-        if (control->count) {
-            buf->len = ngx_sprintf(p, "%uA", ngx_http_vhost_traffic_status_set_by_filter_node_member(
-                                                 control, vtsn, &us)) - p;
-        } else {
-            return NGX_ERROR;
+    ngx_shmtx_lock(&shpool->mutex);
+
+    /* one way out, so that no path can leave the mutex behind */
+
+    node = ngx_http_vhost_traffic_status_find_node(r, &key, control->group, 0);
+
+    if (node == NULL) {
+        rc = NGX_ERROR;
+
+    } else {
+        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+
+        switch (control->group) {
+
+        case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO:
+        case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC:
+        case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG:
+            value = ngx_http_vhost_traffic_status_set_by_filter_node_member(
+                        control, vtsn, &us);
+            found = 1;
+            break;
+
+        case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
+        case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
+            ngx_http_vhost_traffic_status_node_upstream_lookup(control, &us);
+            if (control->count) {
+                value = ngx_http_vhost_traffic_status_set_by_filter_node_member(
+                            control, vtsn, &us);
+                found = 1;
+
+            } else {
+                rc = NGX_ERROR;
+            }
+            break;
         }
-        break;
     }
 
-    return NGX_OK;
+    ngx_shmtx_unlock(&shpool->mutex);
+
+    if (found) {
+        buf->len = ngx_sprintf(p, "%uA", value) - p;
+    }
+
+    return rc;
 }
 
 

--- a/src/ngx_http_vhost_traffic_status_set.c
+++ b/src/ngx_http_vhost_traffic_status_set.c
@@ -369,6 +369,28 @@ ngx_http_vhost_traffic_status_set_by_filter_node(
      * delete command of the control handler.
      */
 
+    /*
+     * The lookup of the server walks the upstreams of the configuration and
+     * does not touch the shared memory, so it stays out of the mutex. Holding
+     * it across that walk costs a third of the throughput of this path once a
+     * thousand groups are configured.
+     *
+     * count is cleared first so that the test below is about this lookup. It
+     * belongs to the request, and the variables of one request share it.
+     */
+
+    switch (control->group) {
+
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
+        control->count = 0;
+        ngx_http_vhost_traffic_status_node_upstream_lookup(control, &us);
+        break;
+
+    default:
+        break;
+    }
+
     rc = NGX_OK;
     found = 0;
     value = 0;
@@ -397,7 +419,6 @@ ngx_http_vhost_traffic_status_set_by_filter_node(
 
         case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
         case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
-            ngx_http_vhost_traffic_status_node_upstream_lookup(control, &us);
             if (control->count) {
                 value = ngx_http_vhost_traffic_status_set_by_filter_node_member(
                             control, vtsn, &us);

--- a/t/034.set_by_filter_lock.t
+++ b/t/034.set_by_filter_lock.t
@@ -1,0 +1,59 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# vhost_traffic_status_set_by_filter reads the tree of the shared memory, and
+# now takes the mutex of the zone to do it, as every other reader does. A path
+# that returned while holding it would wedge the worker, and the one no other
+# test walks is a zone that has no node: the other tests all name a zone that
+# is there.
+#
+# So ask for a peer the group never had, which finds no node, and then ask for
+# something that needs the mutex again. The same worker serves both, so if the
+# mutex were kept the second request would never answer. Removing the unlock
+# on that path does make every request here time out.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each(1) * blocks() * 6;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: a peer the group does not have leaves the zone usable
+--- http_config
+    vhost_traffic_status_zone;
+    log_format basic 'requestCounter:$requestCounter';
+    access_log logs/access.log basic;
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+--- config
+    location /v {
+        set $group upstream@group;
+        set $zone backend@127.0.0.1:1;
+
+        vhost_traffic_status_set_by_filter $requestCounter $group/$zone/requestCounter;
+
+        proxy_pass http://backend/return;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        vhost_traffic_status_bypass_stats on;
+    }
+--- user_files eval
+[
+    ['return/file.txt' => '{"return":"OK"}']
+]
+--- request eval
+[
+    'GET /v/file.txt',
+    'GET /v/file.txt',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'OK',
+    'OK',
+    qr/"hostName"/,
+]


### PR DESCRIPTION
Fixes #355.

## Problem

`vhost_traffic_status_set_by_filter` walked the tree of the shared memory and
read the node it found without taking the mutex of the zone. Every other
reader takes it:

| | mutex |
| --- | --- |
| `shm_add_node()` | held |
| `limit_handler_traffic()` | held |
| `node_variable()`, the `$vts_*` variables | held |
| the display handlers | held |
| `set_by_filter_node()` | **none** |

A node can be taken out of the tree and handed back to the slab while this
one is walking it: by the eviction of `vhost_traffic_status_filter_max_node`,
or by the delete command of the control handler.

## Fix

Take the mutex around the lookup and the read of the node.

The function now has one way out, so no path can return holding the mutex; a
path that did would wedge the worker for good. The formatting of the value is
left outside it, and the average of the time queue keeps using the read only
variant, which works on a copy rather than writing to the queue it is given.

## On testing this

There is no failing-first test here, and I would rather say so than pretend
otherwise. The defect is a race, so nothing makes it fail on demand, and a
sanitizer cannot see it either: the nodes come from `ngx_slab_alloc()`, not
from malloc, so AddressSanitizer does not track them. The `asan` job would
stay green either way.

What `t/034` does cover is the new risk this patch brings, a return that
keeps the mutex. It walks the one way out that no other test reaches — a
zone with no node — and then asks for something that needs the mutex again.
Taking the unlock away makes every request in it time out, so the guard has
teeth:

```
#   Failed test 'ERROR: client socket timed out - t/034 TEST 1: ...'
```

`t/021` already covers the values themselves, for server, upstream, cache and
filter zones, and still passes.

## Cost

Measured with `ab -k -c 32`, a location naming three of these variables, so
three lock acquisitions per request, against a location with none:

| | `set_by_filter` | plain |
| --- | --- | --- |
| master | 157820 req/s | 157500 req/s |
| this branch | 152778 req/s | 162129 req/s |

About 3% on the path that uses it, repeated over three interleaved pairs.
The plain location measured the same on both, so that is the price of this
path rather than noise. It is what every other reader already pays.

## Nearby

While reading this path I found that `find_node()` caches the last node it
returned per type in the location configuration and nothing ever clears it,
so an evicted or deleted node leaves a dangling pointer behind. That is
#362, and it wants fixing before anything makes freeing routine.
