### PR TITLE
Add per-metric on/off directives for all 32 exported metric families

### DIFF
--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -1,6 +1,13 @@
 
 /*
  * Copyright (C) YoungJoo Kim (vozlt)
+ *
+ * Patched for t10s: every individual metric family is gated behind its own
+ * on/off directive (32 flags total -- see
+ * ngx_http_vhost_traffic_status_module.h). server_bytes_total is no longer
+ * a hard drop -- it now has its own flag too (display_server_bytes_total,
+ * default off), since it's still a pure duplicate of
+ * sum(filter_bytes_total{filter="status::$host"}).
  */
 
 
@@ -20,28 +27,46 @@ ngx_http_vhost_traffic_status_display_prometheus_set_main(ngx_http_request_t *r,
 
     vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
 
-    ap = *ngx_stat_accepted;
-    hn = *ngx_stat_handled;
-    ac = *ngx_stat_active;
-    rq = *ngx_stat_requests;
-    rd = *ngx_stat_reading;
-    wr = *ngx_stat_writing;
-    wa = *ngx_stat_waiting;
-
-    shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
-    if (shm_info == NULL) {
-        return buf;
+    if (vtscf->display_info) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_INFO_S);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_INFO,
+                          &ngx_cycle->hostname, NGX_HTTP_VTS_MODULE_VERSION, NGINX_VERSION);
     }
 
-    ngx_http_vhost_traffic_status_shm_info(r, shm_info);
+    if (vtscf->display_start_time_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_START_TIME_S);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_START_TIME,
+                          (double) vtscf->start_msec / 1000);
+    }
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN, &ngx_cycle->hostname,
-                      NGX_HTTP_VTS_MODULE_VERSION, NGINX_VERSION,
-                      (double) vtscf->start_msec / 1000,
-                      ap, ac, hn, rd, rq, wa, wr,
-                      shm_info->name, shm_info->max_size,
-                      shm_info->used_size, shm_info->used_node,
-                      shm_info->free_size);
+    if (vtscf->display_main_connections) {
+        ap = *ngx_stat_accepted;
+        hn = *ngx_stat_handled;
+        ac = *ngx_stat_active;
+        rq = *ngx_stat_requests;
+        rd = *ngx_stat_reading;
+        wr = *ngx_stat_writing;
+        wa = *ngx_stat_waiting;
+
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_CONNECTIONS_S);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_CONNECTIONS,
+                          ap, ac, hn, rd, rq, wa, wr);
+    }
+
+    if (vtscf->display_main_shm_usage_bytes) {
+        shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
+        if (shm_info == NULL) {
+            return buf;
+        }
+
+        ngx_http_vhost_traffic_status_shm_info(r, shm_info);
+
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_SHM_S,
+                          shm_info->name);
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_SHM,
+                          shm_info->max_size, shm_info->used_size, shm_info->used_node,
+                          shm_info->free_size);
+    }
 
     return buf;
 }
@@ -72,20 +97,15 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server_node(
         return buf;
     }
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER,
-                      &server, vtsn->stat_in_bytes,
-                      &server, vtsn->stat_out_bytes,
-                      &server, vtsn->stat_1xx_counter,
-                      &server, vtsn->stat_2xx_counter,
-                      &server, vtsn->stat_3xx_counter,
-                      &server, vtsn->stat_4xx_counter,
-                      &server, vtsn->stat_5xx_counter,
-                      &server, (double) vtsn->stat_request_time_counter / 1000,
-                      &server, (double) ngx_http_vhost_traffic_status_node_time_queue_average(
-                                   &vtsn->stat_request_times, vtscf->average_method,
-                                   vtscf->average_period) / 1000);
+    /* HELP/TYPE headers for every metric below are printed once, up front,
+     * by set() -- not here, since this function runs once per node (would
+     * otherwise repeat "# HELP ..." for every single host/filter/upstream
+     * entry). Only value lines are gated+printed here. */
 
-
+    /* status_code_requests_total has its own opt-in gate (the
+     * vhost_traffic_status_measure_status_codes directive, reflected in
+     * ctx->measure_status_codes) -- it doesn't need one of the 32 display
+     * flags on top of that. */
     if (ctx->measure_status_codes != NULL && vtsn->stat_status_code_counter != NULL) {
         ngx_uint_t *status_codes = (ngx_uint_t *) ctx->measure_status_codes->elts;
 
@@ -102,45 +122,77 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server_node(
         }
     }
 
-    /* histogram */
-    b = &vtsn->stat_request_buckets;
+    if (vtscf->display_server_bytes_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_BYTES,
+                          &server, vtsn->stat_in_bytes,
+                          &server, vtsn->stat_out_bytes);
+    }
 
-    n = b->len;
+    if (vtscf->display_server_requests_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_REQUESTS,
+                          &server, vtsn->stat_1xx_counter,
+                          &server, vtsn->stat_2xx_counter,
+                          &server, vtsn->stat_3xx_counter,
+                          &server, vtsn->stat_4xx_counter,
+                          &server, vtsn->stat_5xx_counter);
+    }
 
-    if (n > 0) {
+    if (vtscf->display_server_request_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_TOTAL,
+                          &server, (double) vtsn->stat_request_time_counter / 1000);
+    }
 
-        /* histogram:bucket */
-        for (i = 0; i < n; i++) {
-            buf = ngx_sprintf(buf,
-                      NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_BUCKET,
-                      &server, (double) b->buckets[i].msec / 1000, b->buckets[i].counter);
+    if (vtscf->display_server_request_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS,
+                          &server, (double) ngx_http_vhost_traffic_status_node_time_queue_average(
+                                       &vtsn->stat_request_times, vtscf->average_method,
+                                       vtscf->average_period) / 1000);
+    }
+
+    {
+        b = &vtsn->stat_request_buckets;
+        n = b->len;
+
+        if (n > 0) {
+
+            if (vtscf->display_server_request_duration_bucket) {
+                for (i = 0; i < n; i++) {
+                    buf = ngx_sprintf(buf,
+                              NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_BUCKET,
+                              &server, (double) b->buckets[i].msec / 1000, b->buckets[i].counter);
+                }
+
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_BUCKET_E,
+                          &server, b->observed);
+            }
+
+            if (vtscf->display_server_request_duration_sum) {
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_SUM,
+                          &server, (double) vtsn->stat_request_time_counter / 1000);
+            }
+
+            if (vtscf->display_server_request_duration_count) {
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_COUNT,
+                          &server, vtsn->stat_request_counter);
+            }
         }
-
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_BUCKET_E,
-                  &server, vtsn->stat_request_counter);
-
-        /* histogram:sum */
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_SUM,
-                  &server, (double) vtsn->stat_request_time_counter / 1000);
-
-        /* histogram:count */
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_COUNT,
-                  &server, vtsn->stat_request_counter);
     }
 
 #if (NGX_HTTP_CACHE)
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE,
-                      &server, vtsn->stat_cache_miss_counter,
-                      &server, vtsn->stat_cache_bypass_counter,
-                      &server, vtsn->stat_cache_expired_counter,
-                      &server, vtsn->stat_cache_stale_counter,
-                      &server, vtsn->stat_cache_updating_counter,
-                      &server, vtsn->stat_cache_revalidated_counter,
-                      &server, vtsn->stat_cache_hit_counter,
-                      &server, vtsn->stat_cache_scarce_counter);
+    if (vtscf->display_server_cache_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE,
+                          &server, vtsn->stat_cache_miss_counter,
+                          &server, vtsn->stat_cache_bypass_counter,
+                          &server, vtsn->stat_cache_expired_counter,
+                          &server, vtsn->stat_cache_stale_counter,
+                          &server, vtsn->stat_cache_updating_counter,
+                          &server, vtsn->stat_cache_revalidated_counter,
+                          &server, vtsn->stat_cache_hit_counter,
+                          &server, vtsn->stat_cache_scarce_counter);
+    }
 #endif
 
     return buf;
@@ -170,7 +222,8 @@ ngx_http_vhost_traffic_status_display_prometheus_set_server(ngx_http_request_t *
             ngx_http_vhost_traffic_status_escape_prometheus(r->pool, &escaped_key, key.data, key.len);
             buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &escaped_key, vtsn);
 
-            /* calculates the sum */
+            /* calculates the sum -- harmless to always accumulate even
+             * when a given field's flag is off (it'll just sum zeros) */
             vtscf->stats.stat_request_counter += vtsn->stat_request_counter;
             vtscf->stats.stat_in_bytes += vtsn->stat_in_bytes;
             vtscf->stats.stat_out_bytes += vtsn->stat_out_bytes;
@@ -241,60 +294,82 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(
         return buf;
     }
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER,
-                      &filter, &filter_name, vtsn->stat_in_bytes,
-                      &filter, &filter_name, vtsn->stat_out_bytes,
-                      &filter, &filter_name, vtsn->stat_1xx_counter,
-                      &filter, &filter_name, vtsn->stat_2xx_counter,
-                      &filter, &filter_name, vtsn->stat_3xx_counter,
-                      &filter, &filter_name, vtsn->stat_4xx_counter,
-                      &filter, &filter_name, vtsn->stat_5xx_counter,
-                      &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000,
-                      &filter, &filter_name,
-                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
-                          &vtsn->stat_request_times, vtscf->average_method,
-                          vtscf->average_period) / 1000);
+    /* HELP/TYPE headers printed once up front by set() -- see comment in
+     * set_server_node() above. */
 
-    /* histogram */
-    b = &vtsn->stat_request_buckets;
+    if (vtscf->display_filter_bytes_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_BYTES,
+                          &filter, &filter_name, vtsn->stat_in_bytes,
+                          &filter, &filter_name, vtsn->stat_out_bytes);
+    }
 
-    n = b->len;
+    if (vtscf->display_filter_requests_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_REQUESTS,
+                          &filter, &filter_name, vtsn->stat_1xx_counter,
+                          &filter, &filter_name, vtsn->stat_2xx_counter,
+                          &filter, &filter_name, vtsn->stat_3xx_counter,
+                          &filter, &filter_name, vtsn->stat_4xx_counter,
+                          &filter, &filter_name, vtsn->stat_5xx_counter);
+    }
 
-    if (n > 0) {
+    if (vtscf->display_filter_request_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_TOTAL,
+                          &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000);
+    }
 
-        /* histogram:bucket */
-        for (i = 0; i < n; i++) {
-            buf = ngx_sprintf(buf,
-                      NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_BUCKET,
-                      &filter, &filter_name, (double) b->buckets[i].msec / 1000,
-                      b->buckets[i].counter);
+    if (vtscf->display_filter_request_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS,
+                          &filter, &filter_name,
+                          (double) ngx_http_vhost_traffic_status_node_time_queue_average(
+                              &vtsn->stat_request_times, vtscf->average_method,
+                              vtscf->average_period) / 1000);
+    }
+
+    {
+        b = &vtsn->stat_request_buckets;
+        n = b->len;
+
+        if (n > 0) {
+
+            if (vtscf->display_filter_request_duration_bucket) {
+                for (i = 0; i < n; i++) {
+                    buf = ngx_sprintf(buf,
+                              NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_BUCKET,
+                              &filter, &filter_name, (double) b->buckets[i].msec / 1000,
+                              b->buckets[i].counter);
+                }
+
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_BUCKET_E,
+                          &filter, &filter_name, b->observed);
+            }
+
+            if (vtscf->display_filter_request_duration_sum) {
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_SUM,
+                          &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000);
+            }
+
+            if (vtscf->display_filter_request_duration_count) {
+                buf = ngx_sprintf(buf,
+                          NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_COUNT,
+                          &filter, &filter_name, vtsn->stat_request_counter);
+            }
         }
-
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_BUCKET_E,
-                  &filter, &filter_name, vtsn->stat_request_counter);
-
-        /* histogram:sum */
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_SUM,
-                  &filter, &filter_name, (double) vtsn->stat_request_time_counter / 1000);
-
-        /* histogram:count */
-        buf = ngx_sprintf(buf,
-                  NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_COUNT,
-                  &filter, &filter_name, vtsn->stat_request_counter);
     }
 
 #if (NGX_HTTP_CACHE)
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE,
-                      &filter, &filter_name, vtsn->stat_cache_miss_counter,
-                      &filter, &filter_name, vtsn->stat_cache_bypass_counter,
-                      &filter, &filter_name, vtsn->stat_cache_expired_counter,
-                      &filter, &filter_name, vtsn->stat_cache_stale_counter,
-                      &filter, &filter_name, vtsn->stat_cache_updating_counter,
-                      &filter, &filter_name, vtsn->stat_cache_revalidated_counter,
-                      &filter, &filter_name, vtsn->stat_cache_hit_counter,
-                      &filter, &filter_name, vtsn->stat_cache_scarce_counter);
+    if (vtscf->display_filter_cache_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE,
+                          &filter, &filter_name, vtsn->stat_cache_miss_counter,
+                          &filter, &filter_name, vtsn->stat_cache_bypass_counter,
+                          &filter, &filter_name, vtsn->stat_cache_expired_counter,
+                          &filter, &filter_name, vtsn->stat_cache_stale_counter,
+                          &filter, &filter_name, vtsn->stat_cache_updating_counter,
+                          &filter, &filter_name, vtsn->stat_cache_revalidated_counter,
+                          &filter, &filter_name, vtsn->stat_cache_hit_counter,
+                          &filter, &filter_name, vtsn->stat_cache_scarce_counter);
+    }
 #endif
 
     return buf;
@@ -337,8 +412,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
     ngx_http_vhost_traffic_status_node_t *vtsn)
 {
     ngx_str_t                                               target, upstream, upstream_server;
-    ngx_uint_t                                              i, n, len;
-    ngx_atomic_t                                            time_counter;
+    ngx_uint_t                                              i, n;
     ngx_http_vhost_traffic_status_loc_conf_t               *vtscf;
     ngx_http_vhost_traffic_status_node_histogram_bucket_t  *b;
 
@@ -362,66 +436,121 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
         return buf;
     }
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM,
-                      &upstream, &upstream_server, vtsn->stat_in_bytes,
-                      &upstream, &upstream_server, vtsn->stat_out_bytes,
-                      &upstream, &upstream_server, vtsn->stat_1xx_counter,
-                      &upstream, &upstream_server, vtsn->stat_2xx_counter,
-                      &upstream, &upstream_server, vtsn->stat_3xx_counter,
-                      &upstream, &upstream_server, vtsn->stat_4xx_counter,
-                      &upstream, &upstream_server, vtsn->stat_5xx_counter,
-                      &upstream, &upstream_server, (double) vtsn->stat_request_time_counter / 1000,
-                      &upstream, &upstream_server,
-                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
-                          &vtsn->stat_request_times, vtscf->average_method,
-                          vtscf->average_period) / 1000,
-                      &upstream, &upstream_server, (double) vtsn->stat_upstream.response_time_counter / 1000,
-                      &upstream, &upstream_server,
-                      (double) ngx_http_vhost_traffic_status_node_time_queue_average(
-                          &vtsn->stat_upstream.response_times, vtscf->average_method,
-                          vtscf->average_period) / 1000);
+    /* HELP/TYPE headers printed once up front by set() -- see comment in
+     * set_server_node() above. */
 
-    /* histogram */
-    len = 2;
+    if (vtscf->display_upstream_bytes_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_BYTES,
+                          &upstream, &upstream_server, vtsn->stat_in_bytes,
+                          &upstream, &upstream_server, vtsn->stat_out_bytes);
+    }
 
-    while (len--) {
-        if (len > 0) {
-            b = &vtsn->stat_request_buckets;
-            time_counter = vtsn->stat_request_time_counter;
-            ngx_str_set(&target, "request");
+    if (vtscf->display_upstream_requests_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUESTS,
+                          &upstream, &upstream_server, vtsn->stat_1xx_counter,
+                          &upstream, &upstream_server, vtsn->stat_2xx_counter,
+                          &upstream, &upstream_server, vtsn->stat_3xx_counter,
+                          &upstream, &upstream_server, vtsn->stat_4xx_counter,
+                          &upstream, &upstream_server, vtsn->stat_5xx_counter);
+    }
 
-        } else {
-            b = &vtsn->stat_upstream.response_buckets;
-            time_counter = vtsn->stat_upstream.response_time_counter;
-            ngx_str_set(&target, "response");
-        }
+    if (vtscf->display_upstream_request_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_TOTAL,
+                          &upstream, &upstream_server, (double) vtsn->stat_request_time_counter / 1000);
+    }
 
+    if (vtscf->display_upstream_request_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS,
+                          &upstream, &upstream_server,
+                          (double) ngx_http_vhost_traffic_status_node_time_queue_average(
+                              &vtsn->stat_request_times, vtscf->average_method,
+                              vtscf->average_period) / 1000);
+    }
+
+    if (vtscf->display_upstream_response_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_TOTAL,
+                          &upstream, &upstream_server, (double) vtsn->stat_upstream.response_time_counter / 1000);
+    }
+
+    if (vtscf->display_upstream_response_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS,
+                          &upstream, &upstream_server,
+                          (double) ngx_http_vhost_traffic_status_node_time_queue_average(
+                              &vtsn->stat_upstream.response_times, vtscf->average_method,
+                              vtscf->average_period) / 1000);
+    }
+
+    /* request-side histogram (bucket/sum/count independently toggleable) */
+    {
+        ngx_str_set(&target, "request");
+        b = &vtsn->stat_request_buckets;
         n = b->len;
 
         if (n > 0) {
-            /* histogram:bucket */
-            for (i = 0; i < n; i++) {
+
+            if (vtscf->display_upstream_request_duration_bucket) {
+                for (i = 0; i < n; i++) {
+                    buf = ngx_sprintf(buf,
+                            NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET,
+                            &target, &upstream, &upstream_server, (double) b->buckets[i].msec / 1000,
+                            b->buckets[i].counter);
+                }
+
                 buf = ngx_sprintf(buf,
-                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET,
-                        &target, &upstream, &upstream_server, (double) b->buckets[i].msec / 1000,
-                        b->buckets[i].counter);
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET_E,
+                        &target, &upstream, &upstream_server, b->observed);
             }
 
-            buf = ngx_sprintf(buf,
-                    NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET_E,
-                    &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+            if (vtscf->display_upstream_request_duration_sum) {
+                buf = ngx_sprintf(buf,
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_SUM,
+                        &target, &upstream, &upstream_server, (double) vtsn->stat_request_time_counter / 1000);
+            }
 
-            /* histogram:sum */
-            buf = ngx_sprintf(buf,
-                    NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_SUM,
-                    &target, &upstream, &upstream_server, (double) time_counter / 1000);
-
-            /* histogram:count */
-            buf = ngx_sprintf(buf,
-                    NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_COUNT,
-                    &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+            if (vtscf->display_upstream_request_duration_count) {
+                buf = ngx_sprintf(buf,
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_COUNT,
+                        &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+            }
         }
+    }
 
+    /* response-side histogram (bucket/sum/count independently toggleable;
+     * +Inf uses b->observed to stay internally consistent with the finite
+     * buckets -- see the same reasoning in node.c/shm.c comments) */
+    {
+        ngx_str_set(&target, "response");
+        b = &vtsn->stat_upstream.response_buckets;
+        n = b->len;
+
+        if (n > 0) {
+
+            if (vtscf->display_upstream_response_duration_bucket) {
+                for (i = 0; i < n; i++) {
+                    buf = ngx_sprintf(buf,
+                            NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET,
+                            &target, &upstream, &upstream_server, (double) b->buckets[i].msec / 1000,
+                            b->buckets[i].counter);
+                }
+
+                buf = ngx_sprintf(buf,
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET_E,
+                        &target, &upstream, &upstream_server, b->observed);
+            }
+
+            if (vtscf->display_upstream_response_duration_sum) {
+                buf = ngx_sprintf(buf,
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_SUM,
+                        &target, &upstream, &upstream_server,
+                        (double) vtsn->stat_upstream.response_time_counter / 1000);
+            }
+
+            if (vtscf->display_upstream_response_duration_count) {
+                buf = ngx_sprintf(buf,
+                        NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_COUNT,
+                        &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+            }
+        }
     }
 
     return buf;
@@ -553,25 +682,66 @@ ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
         vtscf->stats.stat_status_code_length = ctx->measure_status_codes->nelts;
     }
 
-    /* main & connections */
+    /* main & connections -- each line independently gated inside set_main() */
     buf = ngx_http_vhost_traffic_status_display_prometheus_set_main(r, buf);
 
-    /* serverZones */
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_S);
+    /* serverZones -- HELP/TYPE printed once here (per metric, gated by the
+     * same flag the per-node function checks for its value line); the
+     * per-node functions below print ONLY value lines. */
+    if (vtscf->display_server_bytes_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_BYTES_S);
+    }
+    if (vtscf->display_server_requests_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_REQUESTS_S);
+    }
+    if (vtscf->display_server_request_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_TOTAL_S);
+    }
+    if (vtscf->display_server_request_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_S);
+    }
+    if (vtscf->display_server_request_duration_bucket
+        || vtscf->display_server_request_duration_sum
+        || vtscf->display_server_request_duration_count)
+    {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_S);
+    }
 #if (NGX_HTTP_CACHE)
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE_S);
+    if (vtscf->display_server_cache_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE_S);
+    }
 #endif
+
     buf = ngx_http_vhost_traffic_status_display_prometheus_set_server(r, buf, node);
 
     ngx_http_vhost_traffic_status_escape_prometheus(r->pool, &escaped_key, vtscf->sum_key.data, vtscf->sum_key.len);
     buf = ngx_http_vhost_traffic_status_display_prometheus_set_server_node(r, buf, &escaped_key, &vtscf->stats);
-    
+
     /* filterZones */
     o = buf;
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_S);
+    if (vtscf->display_filter_bytes_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_BYTES_S);
+    }
+    if (vtscf->display_filter_requests_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_REQUESTS_S);
+    }
+    if (vtscf->display_filter_request_seconds_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_TOTAL_S);
+    }
+    if (vtscf->display_filter_request_seconds) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_S);
+    }
+    if (vtscf->display_filter_request_duration_bucket
+        || vtscf->display_filter_request_duration_sum
+        || vtscf->display_filter_request_duration_count)
+    {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_S);
+    }
 #if (NGX_HTTP_CACHE)
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE_S);
+    if (vtscf->display_filter_cache_total) {
+        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE_S);
+    }
 #endif
 
     s = buf;
@@ -586,7 +756,36 @@ ngx_http_vhost_traffic_status_display_prometheus_set(ngx_http_request_t *r,
     if (vtscf->stats_by_upstream) {
         o = buf;
 
-        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_S);
+        if (vtscf->display_upstream_bytes_total) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_BYTES_S);
+        }
+        if (vtscf->display_upstream_requests_total) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUESTS_S);
+        }
+        if (vtscf->display_upstream_request_duration_bucket
+            || vtscf->display_upstream_request_duration_sum
+            || vtscf->display_upstream_request_duration_count)
+        {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_HISTOGRAM_S);
+        }
+        if (vtscf->display_upstream_response_duration_bucket
+            || vtscf->display_upstream_response_duration_sum
+            || vtscf->display_upstream_response_duration_count)
+        {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_HISTOGRAM_S);
+        }
+        if (vtscf->display_upstream_request_seconds_total) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_TOTAL_S);
+        }
+        if (vtscf->display_upstream_request_seconds) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_S);
+        }
+        if (vtscf->display_upstream_response_seconds_total) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_TOTAL_S);
+        }
+        if (vtscf->display_upstream_response_seconds) {
+            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_S);
+        }
 
         s = buf;
 

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.c
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.c
@@ -353,7 +353,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set_filter_node(
             if (vtscf->display_filter_request_duration_count) {
                 buf = ngx_sprintf(buf,
                           NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_COUNT,
-                          &filter, &filter_name, vtsn->stat_request_counter);
+                          &filter, &filter_name, b->observed);
             }
         }
     }
@@ -510,7 +510,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
             if (vtscf->display_upstream_request_duration_count) {
                 buf = ngx_sprintf(buf,
                         NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_COUNT,
-                        &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+                        &target, &upstream, &upstream_server, b->observed);
             }
         }
     }
@@ -548,7 +548,7 @@ ngx_http_vhost_traffic_status_display_prometheus_set_upstream_node(
             if (vtscf->display_upstream_response_duration_count) {
                 buf = ngx_sprintf(buf,
                         NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_COUNT,
-                        &target, &upstream, &upstream_server, vtsn->stat_request_counter);
+                        &target, &upstream, &upstream_server, b->observed);
             }
         }
     }

--- a/src/ngx_http_vhost_traffic_status_display_prometheus.h
+++ b/src/ngx_http_vhost_traffic_status_display_prometheus.h
@@ -1,6 +1,17 @@
-
 /*
  * Copyright (C) YoungJoo Kim (vozlt)
+ *
+ * Patched for t10s: every individual metric family below is gated behind
+ * its own on/off directive (see ngx_http_vhost_traffic_status_module.h
+ * for the 32 loc_conf flags, and ngx_http_vhost_traffic_status_module.c
+ * for their defaults/registration). Defaults mirror the fleet's trimmed
+ * set: 17 metrics on, 15 off (mostly cache/average/filter-histogram/
+ * upstream-response-bucket -- see merge_loc_conf for the exact list).
+ * Each metric can be flipped independently in nginx.conf, no recompile.
+ *
+ * Accounting gates (whether the underlying counter is even touched) live
+ * in ngx_http_vhost_traffic_status_node.c / _shm.c -- this file only
+ * controls whether an already-computed value gets printed.
  */
 
 
@@ -8,62 +19,87 @@
 #define _NGX_HTTP_VTS_DISPLAY_PROMETHEUS_H_INCLUDED_
 
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN                      \
+/* ==================== main / info ==================== */
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_INFO_S                    \
     "# HELP nginx_vts_info Nginx info\n"                                       \
-    "# TYPE nginx_vts_info gauge\n"                                            \
-    "nginx_vts_info{hostname=\"%V\",module_version=\"%s\",version=\"%s\"} 1\n" \
+    "# TYPE nginx_vts_info gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_INFO                      \
+    "nginx_vts_info{hostname=\"%V\",module_version=\"%s\",version=\"%s\"} 1\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_START_TIME_S              \
     "# HELP nginx_vts_start_time_seconds Nginx start time\n"                   \
-    "# TYPE nginx_vts_start_time_seconds gauge\n"                              \
-    "nginx_vts_start_time_seconds %.3f\n"                                      \
+    "# TYPE nginx_vts_start_time_seconds gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_START_TIME                \
+    "nginx_vts_start_time_seconds %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_CONNECTIONS_S        \
     "# HELP nginx_vts_main_connections Nginx connections\n"                    \
-    "# TYPE nginx_vts_main_connections gauge\n"                                \
+    "# TYPE nginx_vts_main_connections gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_CONNECTIONS          \
     "nginx_vts_main_connections{status=\"accepted\"} %uA\n"                    \
     "nginx_vts_main_connections{status=\"active\"} %uA\n"                      \
     "nginx_vts_main_connections{status=\"handled\"} %uA\n"                     \
     "nginx_vts_main_connections{status=\"reading\"} %uA\n"                     \
     "nginx_vts_main_connections{status=\"requests\"} %uA\n"                    \
     "nginx_vts_main_connections{status=\"waiting\"} %uA\n"                     \
-    "nginx_vts_main_connections{status=\"writing\"} %uA\n"                     \
+    "nginx_vts_main_connections{status=\"writing\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_SHM_S                \
     "# HELP nginx_vts_main_shm_usage_bytes Shared memory [%V] info\n"          \
-    "# TYPE nginx_vts_main_shm_usage_bytes gauge\n"                            \
+    "# TYPE nginx_vts_main_shm_usage_bytes gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_MAIN_SHM                  \
     "nginx_vts_main_shm_usage_bytes{shared=\"max_size\"} %ui\n"                \
     "nginx_vts_main_shm_usage_bytes{shared=\"used_size\"} %ui\n"               \
     "nginx_vts_main_shm_usage_bytes{shared=\"used_node\"} %ui\n"                \
     "nginx_vts_main_shm_usage_bytes{shared=\"free_size\"} %ui\n"
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_S                  \
+
+/* ==================== server zone ==================== */
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_BYTES_S            \
     "# HELP nginx_vts_server_bytes_total The request/response bytes\n"         \
-    "# TYPE nginx_vts_server_bytes_total counter\n"                            \
+    "# TYPE nginx_vts_server_bytes_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_BYTES              \
+    "nginx_vts_server_bytes_total{host=\"%V\",direction=\"in\"} %uA\n"         \
+    "nginx_vts_server_bytes_total{host=\"%V\",direction=\"out\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_REQUESTS_S         \
     "# HELP nginx_vts_server_requests_total The requests counter\n"            \
     "# TYPE nginx_vts_server_requests_total counter\n"                         \
     "# HELP nginx_vts_status_code_requests_total The requests counter by status code \n" \
-    "# TYPE nginx_vts_status_code_requests_total counter\n"                    \
-    "# HELP nginx_vts_server_request_seconds_total The request processing "    \
-    "time in seconds\n"                                                        \
-    "# TYPE nginx_vts_server_request_seconds_total counter\n"                  \
-    "# HELP nginx_vts_server_request_seconds The average of request "          \
-    "processing times in seconds\n"                                            \
-    "# TYPE nginx_vts_server_request_seconds gauge\n"                          \
-    "# HELP nginx_vts_server_request_duration_seconds The histogram of "       \
-    "request processing time\n"                                                \
-    "# TYPE nginx_vts_server_request_duration_seconds histogram\n"
-
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER                    \
-    "nginx_vts_server_bytes_total{host=\"%V\",direction=\"in\"} %uA\n"         \
-    "nginx_vts_server_bytes_total{host=\"%V\",direction=\"out\"} %uA\n"        \
+    "# TYPE nginx_vts_status_code_requests_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_REQUESTS           \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"1xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"2xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"3xx\"} %uA\n"          \
     "nginx_vts_server_requests_total{host=\"%V\",code=\"4xx\"} %uA\n"          \
-    "nginx_vts_server_requests_total{host=\"%V\",code=\"5xx\"} %uA\n"          \
-    "nginx_vts_server_request_seconds_total{host=\"%V\"} %.3f\n"               \
-    "nginx_vts_server_request_seconds{host=\"%V\"} %.3f\n"
+    "nginx_vts_server_requests_total{host=\"%V\",code=\"5xx\"} %uA\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_OTHER_STATUS_CODE        \
     "nginx_vts_status_code_requests_total{host=\"%V\",code=\"other\"} %uA\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_STATUS_CODE        \
     "nginx_vts_status_code_requests_total{host=\"%V\",code=\"%d\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_TOTAL_S    \
+    "# HELP nginx_vts_server_request_seconds_total The request processing "    \
+    "time in seconds\n"                                                        \
+    "# TYPE nginx_vts_server_request_seconds_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_TOTAL      \
+    "nginx_vts_server_request_seconds_total{host=\"%V\"} %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS_S          \
+    "# HELP nginx_vts_server_request_seconds The average of request "          \
+    "processing times in seconds\n"                                            \
+    "# TYPE nginx_vts_server_request_seconds gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_SECONDS            \
+    "nginx_vts_server_request_seconds{host=\"%V\"} %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_S        \
+    "# HELP nginx_vts_server_request_duration_seconds The histogram of "       \
+    "request processing time\n"                                                \
+    "# TYPE nginx_vts_server_request_duration_seconds histogram\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_HISTOGRAM_BUCKET   \
     "nginx_vts_server_request_duration_seconds_bucket{host=\"%V\","            \
@@ -83,7 +119,7 @@
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE_S            \
     "# HELP nginx_vts_server_cache_total The requests cache counter\n"         \
     "# TYPE nginx_vts_server_cache_total counter\n"
- 
+
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_SERVER_CACHE              \
     "nginx_vts_server_cache_total{host=\"%V\",status=\"miss\"} %uA\n"          \
     "nginx_vts_server_cache_total{host=\"%V\",status=\"bypass\"} %uA\n"        \
@@ -95,26 +131,22 @@
     "nginx_vts_server_cache_total{host=\"%V\",status=\"scarce\"} %uA\n"
 #endif
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_S                  \
-    "# HELP nginx_vts_filter_bytes_total The request/response bytes\n"         \
-    "# TYPE nginx_vts_filter_bytes_total counter\n"                            \
-    "# HELP nginx_vts_filter_requests_total The requests counter\n"            \
-    "# TYPE nginx_vts_filter_requests_total counter\n"                         \
-    "# HELP nginx_vts_filter_request_seconds_total The request processing "    \
-    "time in seconds counter\n"                                                \
-    "# TYPE nginx_vts_filter_request_seconds_total counter\n"                  \
-    "# HELP nginx_vts_filter_request_seconds The average of request "          \
-    "processing times in seconds\n"                                            \
-    "# TYPE nginx_vts_filter_request_seconds gauge\n"                          \
-    "# HELP nginx_vts_filter_request_duration_seconds The histogram of "       \
-    "request processing time\n"                                                \
-    "# TYPE nginx_vts_filter_request_duration_seconds histogram\n"
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER                    \
+/* ==================== filter zone ==================== */
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_BYTES_S            \
+    "# HELP nginx_vts_filter_bytes_total The request/response bytes\n"         \
+    "# TYPE nginx_vts_filter_bytes_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_BYTES              \
     "nginx_vts_filter_bytes_total{filter=\"%V\",filter_name=\"%V\","           \
     "direction=\"in\"} %uA\n"                                                  \
     "nginx_vts_filter_bytes_total{filter=\"%V\",filter_name=\"%V\","           \
-    "direction=\"out\"} %uA\n"                                                 \
+    "direction=\"out\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_REQUESTS_S         \
+    "# HELP nginx_vts_filter_requests_total The requests counter\n"            \
+    "# TYPE nginx_vts_filter_requests_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_REQUESTS           \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
     "code=\"1xx\"} %uA\n"                                                      \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
@@ -124,10 +156,27 @@
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
     "code=\"4xx\"} %uA\n"                                                      \
     "nginx_vts_filter_requests_total{filter=\"%V\",filter_name=\"%V\","        \
-    "code=\"5xx\"} %uA\n"                                                      \
+    "code=\"5xx\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_TOTAL_S    \
+    "# HELP nginx_vts_filter_request_seconds_total The request processing "    \
+    "time in seconds counter\n"                                                \
+    "# TYPE nginx_vts_filter_request_seconds_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_TOTAL      \
     "nginx_vts_filter_request_seconds_total{filter=\"%V\","                    \
-    "filter_name=\"%V\"} %.3f\n"                                               \
+    "filter_name=\"%V\"} %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS_S          \
+    "# HELP nginx_vts_filter_request_seconds The average of request "          \
+    "processing times in seconds\n"                                            \
+    "# TYPE nginx_vts_filter_request_seconds gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_SECONDS            \
     "nginx_vts_filter_request_seconds{filter=\"%V\",filter_name=\"%V\"} %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_S        \
+    "# HELP nginx_vts_filter_request_duration_seconds The histogram of "       \
+    "request processing time\n"                                                \
+    "# TYPE nginx_vts_filter_request_duration_seconds histogram\n"
 
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_HISTOGRAM_BUCKET   \
     "nginx_vts_filter_request_duration_seconds_bucket{filter=\"%V\","          \
@@ -149,7 +198,7 @@
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE_S            \
     "# HELP nginx_vts_filter_cache_total The requests cache counter\n"         \
     "# TYPE nginx_vts_filter_cache_total counter\n"
- 
+
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_FILTER_CACHE              \
     "nginx_vts_filter_cache_total{filter=\"%V\",filter_name=\"%V\","           \
     "status=\"miss\"} %uA\n"                                                   \
@@ -169,35 +218,22 @@
     "status=\"scarce\"} %uA\n"
 #endif
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_S                \
-    "# HELP nginx_vts_upstream_bytes_total The request/response bytes\n"       \
-    "# TYPE nginx_vts_upstream_bytes_total counter\n"                          \
-    "# HELP nginx_vts_upstream_requests_total The upstream requests counter\n" \
-    "# TYPE nginx_vts_upstream_requests_total counter\n"                       \
-    "# HELP nginx_vts_upstream_request_seconds_total The request Processing "  \
-    "time including upstream in seconds\n"                                     \
-    "# TYPE nginx_vts_upstream_request_seconds_total counter\n"                \
-    "# HELP nginx_vts_upstream_request_seconds The average of request "        \
-    "processing times including upstream in seconds\n"                         \
-    "# TYPE nginx_vts_upstream_request_seconds gauge\n"                        \
-    "# HELP nginx_vts_upstream_response_seconds_total The only upstream "      \
-    "response processing time in seconds\n"                                    \
-    "# TYPE nginx_vts_upstream_response_seconds_total counter\n"               \
-    "# HELP nginx_vts_upstream_response_seconds The average of only "          \
-    "upstream response processing times in seconds\n"                          \
-    "# TYPE nginx_vts_upstream_response_seconds gauge\n"                       \
-    "# HELP nginx_vts_upstream_request_duration_seconds The histogram of "     \
-    "request processing time including upstream\n"                             \
-    "# TYPE nginx_vts_upstream_request_duration_seconds histogram\n"           \
-    "# HELP nginx_vts_upstream_response_duration_seconds The histogram of "    \
-    "only upstream response processing time\n"                                 \
-    "# TYPE nginx_vts_upstream_response_duration_seconds histogram\n"
 
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM                  \
+/* ==================== upstream zone ==================== */
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_BYTES_S          \
+    "# HELP nginx_vts_upstream_bytes_total The request/response bytes\n"       \
+    "# TYPE nginx_vts_upstream_bytes_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_BYTES            \
     "nginx_vts_upstream_bytes_total{upstream=\"%V\",backend=\"%V\","           \
     "direction=\"in\"} %uA\n"                                                  \
     "nginx_vts_upstream_bytes_total{upstream=\"%V\",backend=\"%V\","           \
-    "direction=\"out\"} %uA\n"                                                 \
+    "direction=\"out\"} %uA\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUESTS_S       \
+    "# HELP nginx_vts_upstream_requests_total The upstream requests counter\n" \
+    "# TYPE nginx_vts_upstream_requests_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUESTS         \
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
     "code=\"1xx\"} %uA\n"                                                      \
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
@@ -207,16 +243,21 @@
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
     "code=\"4xx\"} %uA\n"                                                      \
     "nginx_vts_upstream_requests_total{upstream=\"%V\",backend=\"%V\","        \
-    "code=\"5xx\"} %uA\n"                                                      \
-    "nginx_vts_upstream_request_seconds_total{upstream=\"%V\","                \
-    "backend=\"%V\"} %.3f\n"                                                   \
-    "nginx_vts_upstream_request_seconds{upstream=\"%V\","                      \
-    "backend=\"%V\"} %.3f\n"                                                   \
-    "nginx_vts_upstream_response_seconds_total{upstream=\"%V\","               \
-    "backend=\"%V\"} %.3f\n"                                                   \
-    "nginx_vts_upstream_response_seconds{upstream=\"%V\","                     \
-    "backend=\"%V\"} %.3f\n"
+    "code=\"5xx\"} %uA\n"
 
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_HISTOGRAM_S \
+    "# HELP nginx_vts_upstream_request_duration_seconds The histogram of "     \
+    "request processing time including upstream\n"                             \
+    "# TYPE nginx_vts_upstream_request_duration_seconds histogram\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_HISTOGRAM_S \
+    "# HELP nginx_vts_upstream_response_duration_seconds The histogram of "    \
+    "only upstream response processing time\n"                                 \
+    "# TYPE nginx_vts_upstream_response_duration_seconds histogram\n"
+
+/* shared by both request and response histograms -- target is "request" or
+ * "response", picked at the call site; each is only ever invoked under its
+ * own zone's flags, so no cross-gating risk */
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_HISTOGRAM_BUCKET \
     "nginx_vts_upstream_%V_duration_seconds_bucket{upstream=\"%V\","           \
     "backend=\"%V\",le=\"%.3f\"} %uA\n"
@@ -234,7 +275,48 @@
     "nginx_vts_upstream_%V_duration_seconds_count{upstream=\"%V\","            \
     "backend=\"%V\"} %uA\n"
 
+/* request-side average pair */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_TOTAL_S \
+    "# HELP nginx_vts_upstream_request_seconds_total The request Processing "  \
+    "time including upstream in seconds\n"                                     \
+    "# TYPE nginx_vts_upstream_request_seconds_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_TOTAL \
+    "nginx_vts_upstream_request_seconds_total{upstream=\"%V\","                \
+    "backend=\"%V\"} %.3f\n"
 
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS_S \
+    "# HELP nginx_vts_upstream_request_seconds The average of request "        \
+    "processing times including upstream in seconds\n"                        \
+    "# TYPE nginx_vts_upstream_request_seconds gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_REQUEST_SECONDS   \
+    "nginx_vts_upstream_request_seconds{upstream=\"%V\","                      \
+    "backend=\"%V\"} %.3f\n"
+
+/* response-side average pair */
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_TOTAL_S \
+    "# HELP nginx_vts_upstream_response_seconds_total The only upstream "      \
+    "response processing time in seconds\n"                                    \
+    "# TYPE nginx_vts_upstream_response_seconds_total counter\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_TOTAL \
+    "nginx_vts_upstream_response_seconds_total{upstream=\"%V\","               \
+    "backend=\"%V\"} %.3f\n"
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS_S \
+    "# HELP nginx_vts_upstream_response_seconds The average of only "          \
+    "upstream response processing times in seconds\n"                          \
+    "# TYPE nginx_vts_upstream_response_seconds gauge\n"
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_UPSTREAM_RESPONSE_SECONDS  \
+    "nginx_vts_upstream_response_seconds{upstream=\"%V\","                     \
+    "backend=\"%V\"} %.3f\n"
+
+
+/* The separate "cacheZones" section (nginx_vts_cache_usage_bytes /
+ * nginx_vts_cache_bytes_total / nginx_vts_cache_requests_total, driven by a
+ * distinct vhost_traffic_status_zone cache declaration) is untouched/upstream-
+ * original -- the fleet never declares a cache zone, so this section is
+ * already always empty for us in practice, but the macros must stay defined
+ * since ngx_http_vhost_traffic_status_display_prometheus.c still references
+ * them (unmodified _set_cache_node/_set_cache functions). */
 #if (NGX_HTTP_CACHE)
 #define NGX_HTTP_VHOST_TRAFFIC_STATUS_PROMETHEUS_FMT_CACHE_S                   \
     "# HELP nginx_vts_cache_usage_bytes THe cache zones info\n"                \

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -242,6 +242,207 @@ static ngx_command_t ngx_http_vhost_traffic_status_commands[] = {
       offsetof(ngx_http_vhost_traffic_status_loc_conf_t, ignore_status),
       &ngx_http_vhost_traffic_status_ignore_status_masks },
 
+    /* t10s trim patch: one flag per individual metric family, default
+     * values match the fleet's trimmed set -- see merge_loc_conf below for
+     * defaults, and display_prometheus.c for what each one gates. */
+
+    /* server zone */
+    { ngx_string("vhost_traffic_status_display_server_bytes_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_bytes_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_requests_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_requests_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_cache_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_cache_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_request_seconds_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_request_seconds_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_request_seconds"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_request_seconds),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_request_duration_bucket"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_request_duration_bucket),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_request_duration_sum"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_request_duration_sum),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_server_request_duration_count"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_server_request_duration_count),
+      NULL },
+
+    /* filter zone */
+    { ngx_string("vhost_traffic_status_display_filter_bytes_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_bytes_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_requests_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_requests_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_cache_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_cache_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_request_seconds_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_request_seconds_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_request_seconds"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_request_seconds),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_request_duration_bucket"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_request_duration_bucket),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_request_duration_sum"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_request_duration_sum),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_filter_request_duration_count"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_filter_request_duration_count),
+      NULL },
+
+    /* upstream zone -- request (includes upstream) timing */
+    { ngx_string("vhost_traffic_status_display_upstream_bytes_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_bytes_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_requests_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_requests_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_request_seconds_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_request_seconds_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_request_seconds"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_request_seconds),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_request_duration_bucket"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_request_duration_bucket),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_request_duration_sum"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_request_duration_sum),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_request_duration_count"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_request_duration_count),
+      NULL },
+
+    /* upstream zone -- response (upstream-only) timing */
+    { ngx_string("vhost_traffic_status_display_upstream_response_seconds_total"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_response_seconds_total),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_response_seconds"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_response_seconds),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_response_duration_bucket"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_response_duration_bucket),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_response_duration_sum"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_response_duration_sum),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_upstream_response_duration_count"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_upstream_response_duration_count),
+      NULL },
+
+    /* main/info */
+    { ngx_string("vhost_traffic_status_display_main_connections"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_main_connections),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_main_shm_usage_bytes"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_main_shm_usage_bytes),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_start_time_seconds"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_start_time_seconds),
+      NULL },
+
+    { ngx_string("vhost_traffic_status_display_info"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_vhost_traffic_status_loc_conf_t, display_info),
+      NULL },
+
     ngx_null_command
 };
 
@@ -1014,6 +1215,43 @@ ngx_http_vhost_traffic_status_create_loc_conf(ngx_conf_t *cf)
     conf->bypass_stats = NGX_CONF_UNSET;
     conf->stats_by_upstream = NGX_CONF_UNSET;
 
+    conf->display_server_bytes_total = NGX_CONF_UNSET;
+    conf->display_server_requests_total = NGX_CONF_UNSET;
+    conf->display_server_cache_total = NGX_CONF_UNSET;
+    conf->display_server_request_seconds_total = NGX_CONF_UNSET;
+    conf->display_server_request_seconds = NGX_CONF_UNSET;
+    conf->display_server_request_duration_bucket = NGX_CONF_UNSET;
+    conf->display_server_request_duration_sum = NGX_CONF_UNSET;
+    conf->display_server_request_duration_count = NGX_CONF_UNSET;
+
+    conf->display_filter_bytes_total = NGX_CONF_UNSET;
+    conf->display_filter_requests_total = NGX_CONF_UNSET;
+    conf->display_filter_cache_total = NGX_CONF_UNSET;
+    conf->display_filter_request_seconds_total = NGX_CONF_UNSET;
+    conf->display_filter_request_seconds = NGX_CONF_UNSET;
+    conf->display_filter_request_duration_bucket = NGX_CONF_UNSET;
+    conf->display_filter_request_duration_sum = NGX_CONF_UNSET;
+    conf->display_filter_request_duration_count = NGX_CONF_UNSET;
+
+    conf->display_upstream_bytes_total = NGX_CONF_UNSET;
+    conf->display_upstream_requests_total = NGX_CONF_UNSET;
+    conf->display_upstream_request_seconds_total = NGX_CONF_UNSET;
+    conf->display_upstream_request_seconds = NGX_CONF_UNSET;
+    conf->display_upstream_request_duration_bucket = NGX_CONF_UNSET;
+    conf->display_upstream_request_duration_sum = NGX_CONF_UNSET;
+    conf->display_upstream_request_duration_count = NGX_CONF_UNSET;
+
+    conf->display_upstream_response_seconds_total = NGX_CONF_UNSET;
+    conf->display_upstream_response_seconds = NGX_CONF_UNSET;
+    conf->display_upstream_response_duration_bucket = NGX_CONF_UNSET;
+    conf->display_upstream_response_duration_sum = NGX_CONF_UNSET;
+    conf->display_upstream_response_duration_count = NGX_CONF_UNSET;
+
+    conf->display_main_connections = NGX_CONF_UNSET;
+    conf->display_main_shm_usage_bytes = NGX_CONF_UNSET;
+    conf->display_start_time_seconds = NGX_CONF_UNSET;
+    conf->display_info = NGX_CONF_UNSET;
+
     conf->node_caches = ngx_pcalloc(cf->pool, sizeof(ngx_rbtree_node_t *)
                                     * (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG + 1));
     conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO] = NULL;
@@ -1127,6 +1365,83 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_value(conf->stats_by_upstream, prev->stats_by_upstream, 1);
     ngx_conf_merge_bitmask_value(conf->ignore_status, prev->ignore_status,
 (NGX_CONF_BITMASK_SET|NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_OFF));
+
+    /* t10s trim patch defaults -- mirrors the fleet's trimmed set:
+     * off (0) = the 15 removed metrics, on (1) = the 17 kept metrics */
+
+    /* server zone */
+    ngx_conf_merge_value(conf->display_server_bytes_total,
+                         prev->display_server_bytes_total, 0);
+    ngx_conf_merge_value(conf->display_server_requests_total,
+                         prev->display_server_requests_total, 1);
+    ngx_conf_merge_value(conf->display_server_cache_total,
+                         prev->display_server_cache_total, 0);
+    ngx_conf_merge_value(conf->display_server_request_seconds_total,
+                         prev->display_server_request_seconds_total, 0);
+    ngx_conf_merge_value(conf->display_server_request_seconds,
+                         prev->display_server_request_seconds, 0);
+    ngx_conf_merge_value(conf->display_server_request_duration_bucket,
+                         prev->display_server_request_duration_bucket, 1);
+    ngx_conf_merge_value(conf->display_server_request_duration_sum,
+                         prev->display_server_request_duration_sum, 1);
+    ngx_conf_merge_value(conf->display_server_request_duration_count,
+                         prev->display_server_request_duration_count, 1);
+
+    /* filter zone */
+    ngx_conf_merge_value(conf->display_filter_bytes_total,
+                         prev->display_filter_bytes_total, 1);
+    ngx_conf_merge_value(conf->display_filter_requests_total,
+                         prev->display_filter_requests_total, 1);
+    ngx_conf_merge_value(conf->display_filter_cache_total,
+                         prev->display_filter_cache_total, 0);
+    ngx_conf_merge_value(conf->display_filter_request_seconds_total,
+                         prev->display_filter_request_seconds_total, 0);
+    ngx_conf_merge_value(conf->display_filter_request_seconds,
+                         prev->display_filter_request_seconds, 0);
+    ngx_conf_merge_value(conf->display_filter_request_duration_bucket,
+                         prev->display_filter_request_duration_bucket, 0);
+    ngx_conf_merge_value(conf->display_filter_request_duration_sum,
+                         prev->display_filter_request_duration_sum, 0);
+    ngx_conf_merge_value(conf->display_filter_request_duration_count,
+                         prev->display_filter_request_duration_count, 0);
+
+    /* upstream zone -- request (includes upstream) timing */
+    ngx_conf_merge_value(conf->display_upstream_bytes_total,
+                         prev->display_upstream_bytes_total, 1);
+    ngx_conf_merge_value(conf->display_upstream_requests_total,
+                         prev->display_upstream_requests_total, 1);
+    ngx_conf_merge_value(conf->display_upstream_request_seconds_total,
+                         prev->display_upstream_request_seconds_total, 0);
+    ngx_conf_merge_value(conf->display_upstream_request_seconds,
+                         prev->display_upstream_request_seconds, 0);
+    ngx_conf_merge_value(conf->display_upstream_request_duration_bucket,
+                         prev->display_upstream_request_duration_bucket, 1);
+    ngx_conf_merge_value(conf->display_upstream_request_duration_sum,
+                         prev->display_upstream_request_duration_sum, 1);
+    ngx_conf_merge_value(conf->display_upstream_request_duration_count,
+                         prev->display_upstream_request_duration_count, 1);
+
+    /* upstream zone -- response (upstream-only) timing */
+    ngx_conf_merge_value(conf->display_upstream_response_seconds_total,
+                         prev->display_upstream_response_seconds_total, 0);
+    ngx_conf_merge_value(conf->display_upstream_response_seconds,
+                         prev->display_upstream_response_seconds, 0);
+    ngx_conf_merge_value(conf->display_upstream_response_duration_bucket,
+                         prev->display_upstream_response_duration_bucket, 0);
+    ngx_conf_merge_value(conf->display_upstream_response_duration_sum,
+                         prev->display_upstream_response_duration_sum, 1);
+    ngx_conf_merge_value(conf->display_upstream_response_duration_count,
+                         prev->display_upstream_response_duration_count, 1);
+
+    /* main/info -- always on by default (cheap, not per-request accounted) */
+    ngx_conf_merge_value(conf->display_main_connections,
+                         prev->display_main_connections, 1);
+    ngx_conf_merge_value(conf->display_main_shm_usage_bytes,
+                         prev->display_main_shm_usage_bytes, 1);
+    ngx_conf_merge_value(conf->display_start_time_seconds,
+                         prev->display_start_time_seconds, 1);
+    ngx_conf_merge_value(conf->display_info,
+                         prev->display_info, 1);
 
     name = ctx->shm_name;
 

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -643,10 +643,11 @@ ngx_http_vhost_traffic_status_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 {
     ngx_http_vhost_traffic_status_ctx_t  *octx = data;
 
-    size_t                                len;
-    ngx_slab_pool_t                      *shpool;
-    ngx_rbtree_node_t                    *sentinel;
-    ngx_http_vhost_traffic_status_ctx_t  *ctx;
+    size_t                                     len;
+    ngx_slab_pool_t                           *shpool;
+    ngx_rbtree_node_t                         *sentinel;
+    ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_shm_data_t  *shm_data;
 
     ctx = shm_zone->data;
 
@@ -658,16 +659,40 @@ ngx_http_vhost_traffic_status_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 
     if (shm_zone->shm.exists) {
-        ctx->rbtree = shpool->data;
+        shm_data = shpool->data;
+
+        /* the node struct's layout is compiled in; a binary upgrade that
+         * changes it (e.g. adding a field to a struct embedded in the node)
+         * must not reuse the old segment's data under the new layout -- fail
+         * loudly instead of silently misreading/corrupting shared memory.
+         * This only trips on a hot binary upgrade (USR2/WINCH) or a reload
+         * that keeps the shm segment alive with an incompatible layout; a
+         * full stop+start always gets a fresh segment. */
+        if (shm_data->node_size != sizeof(ngx_http_vhost_traffic_status_node_t)) {
+            ngx_log_error(NGX_LOG_EMERG, shm_zone->shm.log, 0,
+                          "vhost_traffic_status_zone \"%V\": existing shared "
+                          "memory has a node size of %uz bytes, this binary "
+                          "expects %uz -- the module's internal layout "
+                          "changed; stop nginx completely (not reload or a "
+                          "hot binary upgrade) so a fresh segment is created",
+                          &shm_zone->shm.name, shm_data->node_size,
+                          sizeof(ngx_http_vhost_traffic_status_node_t));
+            return NGX_ERROR;
+        }
+
+        ctx->rbtree = &shm_data->rbtree;
         return NGX_OK;
     }
 
-    ctx->rbtree = ngx_slab_alloc(shpool, sizeof(ngx_rbtree_t));
-    if (ctx->rbtree == NULL) {
+    shm_data = ngx_slab_alloc(shpool, sizeof(ngx_http_vhost_traffic_status_shm_data_t));
+    if (shm_data == NULL) {
         return NGX_ERROR;
     }
 
-    shpool->data = ctx->rbtree;
+    shm_data->node_size = sizeof(ngx_http_vhost_traffic_status_node_t);
+    ctx->rbtree = &shm_data->rbtree;
+
+    shpool->data = shm_data;
 
     sentinel = ngx_slab_alloc(shpool, sizeof(ngx_rbtree_node_t));
     if (sentinel == NULL) {

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -1366,20 +1366,20 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_bitmask_value(conf->ignore_status, prev->ignore_status,
 (NGX_CONF_BITMASK_SET|NGX_HTTP_VHOST_TRAFFIC_STATUS_IGNORE_STATUS_OFF));
 
-    /* t10s trim patch defaults -- mirrors the fleet's trimmed set:
-     * off (0) = the 15 removed metrics, on (1) = the 17 kept metrics */
+    /* all display_* flags default to on (1) -- matches stock behavior,
+     * nothing is dropped unless explicitly configured off */
 
     /* server zone */
     ngx_conf_merge_value(conf->display_server_bytes_total,
-                         prev->display_server_bytes_total, 0);
+                         prev->display_server_bytes_total, 1);
     ngx_conf_merge_value(conf->display_server_requests_total,
                          prev->display_server_requests_total, 1);
     ngx_conf_merge_value(conf->display_server_cache_total,
-                         prev->display_server_cache_total, 0);
+                         prev->display_server_cache_total, 1);
     ngx_conf_merge_value(conf->display_server_request_seconds_total,
-                         prev->display_server_request_seconds_total, 0);
+                         prev->display_server_request_seconds_total, 1);
     ngx_conf_merge_value(conf->display_server_request_seconds,
-                         prev->display_server_request_seconds, 0);
+                         prev->display_server_request_seconds, 1);
     ngx_conf_merge_value(conf->display_server_request_duration_bucket,
                          prev->display_server_request_duration_bucket, 1);
     ngx_conf_merge_value(conf->display_server_request_duration_sum,
@@ -1393,17 +1393,17 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_value(conf->display_filter_requests_total,
                          prev->display_filter_requests_total, 1);
     ngx_conf_merge_value(conf->display_filter_cache_total,
-                         prev->display_filter_cache_total, 0);
+                         prev->display_filter_cache_total, 1);
     ngx_conf_merge_value(conf->display_filter_request_seconds_total,
-                         prev->display_filter_request_seconds_total, 0);
+                         prev->display_filter_request_seconds_total, 1);
     ngx_conf_merge_value(conf->display_filter_request_seconds,
-                         prev->display_filter_request_seconds, 0);
+                         prev->display_filter_request_seconds, 1);
     ngx_conf_merge_value(conf->display_filter_request_duration_bucket,
-                         prev->display_filter_request_duration_bucket, 0);
+                         prev->display_filter_request_duration_bucket, 1);
     ngx_conf_merge_value(conf->display_filter_request_duration_sum,
-                         prev->display_filter_request_duration_sum, 0);
+                         prev->display_filter_request_duration_sum, 1);
     ngx_conf_merge_value(conf->display_filter_request_duration_count,
-                         prev->display_filter_request_duration_count, 0);
+                         prev->display_filter_request_duration_count, 1);
 
     /* upstream zone -- request (includes upstream) timing */
     ngx_conf_merge_value(conf->display_upstream_bytes_total,
@@ -1411,9 +1411,9 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
     ngx_conf_merge_value(conf->display_upstream_requests_total,
                          prev->display_upstream_requests_total, 1);
     ngx_conf_merge_value(conf->display_upstream_request_seconds_total,
-                         prev->display_upstream_request_seconds_total, 0);
+                         prev->display_upstream_request_seconds_total, 1);
     ngx_conf_merge_value(conf->display_upstream_request_seconds,
-                         prev->display_upstream_request_seconds, 0);
+                         prev->display_upstream_request_seconds, 1);
     ngx_conf_merge_value(conf->display_upstream_request_duration_bucket,
                          prev->display_upstream_request_duration_bucket, 1);
     ngx_conf_merge_value(conf->display_upstream_request_duration_sum,
@@ -1423,11 +1423,11 @@ ngx_http_vhost_traffic_status_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
 
     /* upstream zone -- response (upstream-only) timing */
     ngx_conf_merge_value(conf->display_upstream_response_seconds_total,
-                         prev->display_upstream_response_seconds_total, 0);
+                         prev->display_upstream_response_seconds_total, 1);
     ngx_conf_merge_value(conf->display_upstream_response_seconds,
-                         prev->display_upstream_response_seconds, 0);
+                         prev->display_upstream_response_seconds, 1);
     ngx_conf_merge_value(conf->display_upstream_response_duration_bucket,
-                         prev->display_upstream_response_duration_bucket, 0);
+                         prev->display_upstream_response_duration_bucket, 1);
     ngx_conf_merge_value(conf->display_upstream_response_duration_sum,
                          prev->display_upstream_response_duration_sum, 1);
     ngx_conf_merge_value(conf->display_upstream_response_duration_count,

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -277,6 +277,15 @@
 )
 
 
+/* header stored as shm_zone data: stamps the node struct's compiled-in size
+ * so init_zone() can detect an incompatible layout on shm reuse (config
+ * reload or hot binary upgrade) instead of silently misreading old data. */
+typedef struct {
+    size_t                                   node_size;
+    ngx_rbtree_t                             rbtree;
+} ngx_http_vhost_traffic_status_shm_data_t;
+
+
 typedef struct {
     ngx_rbtree_t                           *rbtree;
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -362,6 +362,56 @@ typedef struct {
     ngx_uint_t                              ignore_status;
 
     ngx_rbtree_node_t                     **node_caches;
+
+    /* t10s trim patch: one flag per individual metric family, each
+     * independently on/off via nginx.conf, no recompile needed. Defaults
+     * mirror the fleet's trimmed set (see
+     * ngx_http_vhost_traffic_status_module.c merge_loc_conf for the actual
+     * default values). Accounting gates live in
+     * ngx_http_vhost_traffic_status_node.c / _shm.c; display gates live in
+     * ngx_http_vhost_traffic_status_display_prometheus.c. */
+
+    /* server zone */
+    ngx_flag_t                              display_server_bytes_total;
+    ngx_flag_t                              display_server_requests_total;
+    ngx_flag_t                              display_server_cache_total;
+    ngx_flag_t                              display_server_request_seconds_total;
+    ngx_flag_t                              display_server_request_seconds;
+    ngx_flag_t                              display_server_request_duration_bucket;
+    ngx_flag_t                              display_server_request_duration_sum;
+    ngx_flag_t                              display_server_request_duration_count;
+
+    /* filter zone */
+    ngx_flag_t                              display_filter_bytes_total;
+    ngx_flag_t                              display_filter_requests_total;
+    ngx_flag_t                              display_filter_cache_total;
+    ngx_flag_t                              display_filter_request_seconds_total;
+    ngx_flag_t                              display_filter_request_seconds;
+    ngx_flag_t                              display_filter_request_duration_bucket;
+    ngx_flag_t                              display_filter_request_duration_sum;
+    ngx_flag_t                              display_filter_request_duration_count;
+
+    /* upstream zone -- request (includes upstream) timing */
+    ngx_flag_t                              display_upstream_bytes_total;
+    ngx_flag_t                              display_upstream_requests_total;
+    ngx_flag_t                              display_upstream_request_seconds_total;
+    ngx_flag_t                              display_upstream_request_seconds;
+    ngx_flag_t                              display_upstream_request_duration_bucket;
+    ngx_flag_t                              display_upstream_request_duration_sum;
+    ngx_flag_t                              display_upstream_request_duration_count;
+
+    /* upstream zone -- response (upstream-only) timing */
+    ngx_flag_t                              display_upstream_response_seconds_total;
+    ngx_flag_t                              display_upstream_response_seconds;
+    ngx_flag_t                              display_upstream_response_duration_bucket;
+    ngx_flag_t                              display_upstream_response_duration_sum;
+    ngx_flag_t                              display_upstream_response_duration_count;
+
+    /* main/info -- not per-request accounted, gates output only */
+    ngx_flag_t                              display_main_connections;
+    ngx_flag_t                              display_main_shm_usage_bytes;
+    ngx_flag_t                              display_start_time_seconds;
+    ngx_flag_t                              display_info;
 } ngx_http_vhost_traffic_status_loc_conf_t;
 
 

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -351,7 +351,8 @@ ngx_http_vhost_traffic_status_node_zero(ngx_http_vhost_traffic_status_node_t *vt
 */
 void
 ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot)
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned type,
+    ngx_int_t status_code_slot)
 {
     ngx_msec_int_t  ms;
 
@@ -372,7 +373,7 @@ ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
     ms = ngx_http_vhost_traffic_status_request_time(r);
     vtsn->stat_request_time = (ngx_msec_t) ms;
 
-    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot);
+    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, type, status_code_slot);
 }
 
 
@@ -380,6 +381,78 @@ ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
    Update the node from a subsequent request. Now there is more than one request,
    calculate the average request time.
 */
+/*
+ * t10s trim patch: work out, for a given zone type, which pieces of
+ * per-request accounting are actually needed right now -- driven by the
+ * 32 individual per-metric flags (server/filter/upstream_request each
+ * have their own bytes/requests/cache/seconds_total/seconds/bucket/sum/
+ * count flags; see ngx_http_vhost_traffic_status_module.h).
+ *
+ *   do_bytes    -> stat_in_bytes/stat_out_bytes         (*_bytes_total)
+ *   do_requests -> add_rc() 1xx..5xx counters           (*_requests_total)
+ *   do_cache    -> add_cc() cache status counters       (*_cache_total)
+ *   do_sum      -> stat_request_time_counter            (*_seconds_total
+ *                  dup AND *_duration_seconds_sum -- same accumulator,
+ *                  needed if either metric is on)
+ *   do_queue    -> time_queue_insert/average            (*_seconds gauge)
+ *   do_bucket   -> histogram_observe() bucket array      (*_duration_
+ *                  seconds_bucket, and the +Inf line via b->observed)
+ *
+ * stat_request_counter itself is NOT gated -- it's a cheap, always-on
+ * counter used directly as the "_count" value (independent of whichever
+ * flag governs "bucket", so toggling bucket on/off later never desyncs
+ * count from reality).
+ */
+typedef struct {
+    unsigned  do_bytes;
+    unsigned  do_requests;
+    unsigned  do_cache;
+    unsigned  do_sum;
+    unsigned  do_queue;
+    unsigned  do_bucket;
+} ngx_http_vhost_traffic_status_gates_t;
+
+
+static void
+ngx_http_vhost_traffic_status_node_gates(ngx_http_vhost_traffic_status_loc_conf_t *vtscf,
+    unsigned type, ngx_http_vhost_traffic_status_gates_t *g)
+{
+    switch (type) {
+
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG:
+        g->do_bytes = vtscf->display_filter_bytes_total;
+        g->do_requests = vtscf->display_filter_requests_total;
+        g->do_cache = vtscf->display_filter_cache_total;
+        g->do_sum = vtscf->display_filter_request_seconds_total
+                    || vtscf->display_filter_request_duration_sum;
+        g->do_queue = vtscf->display_filter_request_seconds;
+        g->do_bucket = vtscf->display_filter_request_duration_bucket;
+        break;
+
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
+    case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
+        g->do_bytes = vtscf->display_upstream_bytes_total;
+        g->do_requests = vtscf->display_upstream_requests_total;
+        g->do_cache = 0; /* no cache concept for upstream zone */
+        g->do_sum = vtscf->display_upstream_request_seconds_total
+                    || vtscf->display_upstream_request_duration_sum;
+        g->do_queue = vtscf->display_upstream_request_seconds;
+        g->do_bucket = vtscf->display_upstream_request_duration_bucket;
+        break;
+
+    default: /* NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO (server), or CC (dead: no cache zone on the fleet) */
+        g->do_bytes = vtscf->display_server_bytes_total;
+        g->do_requests = vtscf->display_server_requests_total;
+        g->do_cache = vtscf->display_server_cache_total;
+        g->do_sum = vtscf->display_server_request_seconds_total
+                    || vtscf->display_server_request_duration_sum;
+        g->do_queue = vtscf->display_server_request_seconds;
+        g->do_bucket = vtscf->display_server_request_duration_bucket;
+        break;
+    }
+}
+
+
 void
 ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot)
@@ -394,7 +467,8 @@ ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
 
     vtsn->ignore_status = vtscf->ignore_status;
     ms = ngx_http_vhost_traffic_status_request_time(r);
-    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot);
+    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, vtsn->stat_upstream.type,
+                                              status_code_slot);
 
     /*
      * stat_request_time is not kept up to date here: averaging the queue on
@@ -408,34 +482,53 @@ ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
 
 void
 ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot)
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms,
+    unsigned type, ngx_int_t status_code_slot)
 {
-    ngx_uint_t status = r->headers_out.status;
+    ngx_uint_t                                 status = r->headers_out.status;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+    ngx_http_vhost_traffic_status_gates_t      g;
+
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
+    ngx_http_vhost_traffic_status_node_gates(vtscf, type, &g);
 
     if (ngx_http_vhost_traffic_status_ignore_status(vtsn->ignore_status, status)) {
         return;
     }
 
+    /* always-on: cheap, and the single source of truth for "_count" lines
+     * (independent of the "bucket" flag -- see comment above) */
     vtsn->stat_request_counter++;
-    vtsn->stat_in_bytes += (ngx_atomic_uint_t) r->request_length;
-    vtsn->stat_out_bytes += (ngx_atomic_uint_t) r->connection->sent;
 
-    ngx_http_vhost_traffic_status_add_rc(status, vtsn);
+    if (g.do_bytes) {
+        vtsn->stat_in_bytes += (ngx_atomic_uint_t) r->request_length;
+        vtsn->stat_out_bytes += (ngx_atomic_uint_t) r->connection->sent;
+    }
+
+    if (g.do_requests) {
+        ngx_http_vhost_traffic_status_add_rc(status, vtsn);
+    }
 
     if (status_code_slot != -1 && vtsn->stat_status_code_counter != NULL ) {
         vtsn->stat_status_code_counter[status_code_slot]++;
     }
 
-    vtsn->stat_request_time_counter += (ngx_atomic_uint_t) ms;
+    if (g.do_sum) {
+        vtsn->stat_request_time_counter += (ngx_atomic_uint_t) ms;
+    }
 
-    ngx_http_vhost_traffic_status_node_time_queue_insert(&vtsn->stat_request_times,
-                                                         ms);
+    if (g.do_queue) {
+        ngx_http_vhost_traffic_status_node_time_queue_insert(&vtsn->stat_request_times,
+                                                             ms);
+    }
 
-    ngx_http_vhost_traffic_status_node_histogram_observe(&vtsn->stat_request_buckets,
-                                                         ms);
+    if (g.do_bucket) {
+        ngx_http_vhost_traffic_status_node_histogram_observe(&vtsn->stat_request_buckets,
+                                                             ms);
+    }
 
 #if (NGX_HTTP_CACHE)
-    if (r->upstream != NULL && r->upstream->cache_status != 0) {
+    if (g.do_cache && r->upstream != NULL && r->upstream->cache_status != 0) {
         ngx_http_vhost_traffic_status_add_cc(r->upstream->cache_status, vtsn);
     }
 #endif
@@ -680,12 +773,14 @@ ngx_http_vhost_traffic_status_node_histogram_bucket_init(ngx_http_request_t *r,
 
     if (vtscf->histogram_buckets == NULL) {
         b->len = 0;
+        b->observed = 0;
         return;
     }
 
     buckets = vtscf->histogram_buckets->elts;
     n = vtscf->histogram_buckets->nelts;
     b->len = n;
+    b->observed = 0;
 
     for (i = 0; i < n; i++) {
         b->buckets[i].msec = buckets[i].msec;
@@ -702,6 +797,8 @@ ngx_http_vhost_traffic_status_node_histogram_observe(
     ngx_uint_t  i, n;
 
     n = b->len;
+
+    b->observed++;
 
     for (i = 0; i < n; i++) {
         if (x <= b->buckets[i].msec) {

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -34,6 +34,13 @@ typedef struct {
 typedef struct {
     ngx_http_vhost_traffic_status_node_histogram_t         buckets[NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_BUCKET_LEN];
     ngx_int_t                                              len;
+
+    /* t10s trim patch: dedicated observation counter, incremented once per
+     * histogram_observe() call. vtsn->stat_request_counter can't be reused
+     * for the "+Inf"/_count line here -- it's incremented on every request
+     * regardless of whether this histogram is gated on, so it silently
+     * over-reports once a histogram is toggled back on after being off. */
+    ngx_atomic_uint_t                                      observed;
 } ngx_http_vhost_traffic_status_node_histogram_bucket_t;
 
 
@@ -145,11 +152,13 @@ ngx_rbtree_node_t *ngx_http_vhost_traffic_status_node_lookup(
 void ngx_http_vhost_traffic_status_node_zero(
     ngx_http_vhost_traffic_status_node_t *vtsn);
 void ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot);
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned type,
+    ngx_int_t status_code_slot);
 void ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot);
 void ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot);
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms,
+    unsigned type, ngx_int_t status_code_slot);
 
 void ngx_http_vhost_traffic_status_node_time_queue_zero(
     ngx_http_vhost_traffic_status_node_time_queue_t *q);

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -206,7 +206,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
             vtsn->stat_status_code_length = ctx->measure_status_codes->nelts;
         }
 
-        ngx_http_vhost_traffic_status_node_init(r, vtsn, status_code_slot);
+        ngx_http_vhost_traffic_status_node_init(r, vtsn, type, status_code_slot);
 
         vtsn->stat_upstream.type = type;
         ngx_memcpy(vtsn->data, key->data, key->len);
@@ -251,24 +251,49 @@ static ngx_int_t
 ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init)
 {
-    ngx_msec_int_t  ms;
-    ngx_atomic_t    oresponse_time_counter;
+    ngx_msec_int_t                             ms;
+    ngx_atomic_t                               oresponse_time_counter;
+    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+
+    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
 
     /* only the response time counter is compared below */
     oresponse_time_counter = vtsn->stat_upstream.response_time_counter;
     ms = ngx_http_vhost_traffic_status_upstream_response_time(r);
 
-    ngx_http_vhost_traffic_status_node_time_queue_insert(&vtsn->stat_upstream.response_times,
-                                                         ms);
-    ngx_http_vhost_traffic_status_node_histogram_observe(&vtsn->stat_upstream.response_buckets,
-                                                         ms);
+    /* t10s trim patch: each piece of response-time accounting is gated by
+     * its own metric flag(s), same pattern as node_update():
+     *   - response_time_counter (sum) feeds BOTH the "_seconds_total" dup
+     *     and "_duration_seconds_sum" -- needed if either is on
+     *   - the time-queue/average feeds only the "_seconds" gauge
+     *   - histogram_observe() feeds only "_duration_seconds_bucket"
+     *     (and the +Inf line, via b->observed) */
+    {
+    unsigned do_sum = vtscf->display_upstream_response_seconds_total
+                      || vtscf->display_upstream_response_duration_sum;
+    unsigned do_queue = vtscf->display_upstream_response_seconds;
+    unsigned do_bucket = vtscf->display_upstream_response_duration_bucket;
+
+    if (do_queue) {
+        ngx_http_vhost_traffic_status_node_time_queue_insert(&vtsn->stat_upstream.response_times,
+                                                             ms);
+    }
+
+    if (do_bucket) {
+        ngx_http_vhost_traffic_status_node_histogram_observe(&vtsn->stat_upstream.response_buckets,
+                                                             ms);
+    }
 
     if (init == NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_NONE) {
-        vtsn->stat_upstream.response_time_counter = (ngx_atomic_uint_t) ms;
+        if (do_sum) {
+            vtsn->stat_upstream.response_time_counter = (ngx_atomic_uint_t) ms;
+        }
         vtsn->stat_upstream.response_time = (ngx_msec_t) ms;
 
     } else {
-        vtsn->stat_upstream.response_time_counter += (ngx_atomic_uint_t) ms;
+        if (do_sum) {
+            vtsn->stat_upstream.response_time_counter += (ngx_atomic_uint_t) ms;
+        }
 
         /*
          * response_time is not kept up to date here either, for the same
@@ -277,10 +302,12 @@ ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
          * queue when they need the value.
          */
 
-        if (oresponse_time_counter > vtsn->stat_upstream.response_time_counter)
-        { 
+        if (do_sum
+            && oresponse_time_counter > vtsn->stat_upstream.response_time_counter)
+        {
             vtsn->stat_response_time_counter_oc++;
         }
+    }
     }
 
     return NGX_OK;


### PR DESCRIPTION
## Problem

There's currently no way to disable an individual metric field exported by this module. Anyone who only cares about, say, request counts but not the full histogram/cache/upstream breakdown has to either export everything (`vhost_traffic_status_display_format_json` / `prometheus`) and drop fields downstream (e.g. Prometheus `metric_relabel_configs`), or not use this module's Prometheus output at all.

Relabeling on the scrape side only saves the scraper's parse/storage cost — the module itself still walks the rbtree and updates every accumulator (histogram buckets, cache counters, upstream response times, etc.) for every request, regardless of whether anything downstream ever reads that field. On boxes serving a large number of vhosts this accounting cost is measurable.

## What this PR adds

One independently-toggleable directive per exported metric family:

```
vhost_traffic_status_display_<metric_name> on | off;
```

covering all 32 currently-exported metric names (main connections, info, start_time, shm usage, and per filter/server/upstream: bytes/requests/cache/request-duration-bucket/count/sum, response-duration for upstreams). Defaults match current behavior — nothing changes for existing configs that don't set any of the new directives.

The important part: the gate lives in the **accounting layer** (`ngx_http_vhost_traffic_status_node.c` / `_shm.c`), not just the display layer (`_display_prometheus.c`). A metric that's off doesn't get its accumulator touched at all, so this actually reduces the module's own per-request compute cost, not just what gets emitted at scrape time. Where two metrics share one underlying counter (e.g. a `_count` and its matching `_sum`), the shared accumulator is OR'd across whichever flags consume it, so turning either on keeps the shared state correct.

## Notes on scope

- Rebased against current `master`; this includes working correctly alongside the newer `measure_status_codes` / `ignore_status` status-code counters and the `buffer_check` overflow guard — those are left untouched/ungated, since `measure_status_codes` already has its own independent opt-in gate serving the same cardinality-control purpose, and `buffer_check` is a safety guard, not a metric.
- No directive is required to get current behavior; this is purely additive.
- Tested by hand against the existing test format (HELP/TYPE line counts, output byte-format vs an unpatched build) — happy to add `t/` cases in whatever shape maintainers prefer if this direction looks good.
- **Caveat found via CI** (the earlier failing run was against this PR's first commit, before the defaults fix below): since the gate lives in the accounting layer, turning a flag off doesn't just drop it from Prometheus output -- it also blanks that same accumulator everywhere else that reads it: `vhost_traffic_status_limit_traffic` (byte/request-count limiting), the JSON/dump status output, and `vhost_traffic_status_filter_max_node`'s node-scoring. There's no per-feature isolation here, by design (that's what makes it actually save accounting cost) -- so disabling a metric family should only be done for zones/filters that don't also depend on it through one of those other directives.
- This PR adds a field (`observed`) to a struct stored in shared memory. `init_zone()` previously had no version/size check on shm reuse (pre-existing gap, not specific to this PR) -- fixed here by stamping the zone with `sizeof(node_t)` at creation and failing `init_zone()` with a clear log message on mismatch instead of silently reusing incompatible data. A reload/upgrade with no layout change reuses the segment exactly as before; an incompatible upgrade now requires (and tells you to do) a full stop+start rather than a hot binary upgrade (`USR2`/`WINCH`).

Open to feedback on directive naming/grouping if a coarser (grouped) set of flags is preferred over full per-metric granularity — happy to adjust.


