### PR TITLE
Read the sources for the two mistakes around the zone mutex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,3 +244,12 @@ jobs:
       - name: 'build'
         working-directory: front
         run: npm run build
+
+  lockcheck:
+    name: 'lock discipline'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 'read the sources'
+        run: python3 util/lockcheck.py

--- a/util/lockcheck.py
+++ b/util/lockcheck.py
@@ -149,6 +149,22 @@ def check(path):
     return findings
 
 
+def stale(paths):
+    """Names in CALLED_LOCKED that no longer belong to any function.
+
+    An entry that has outlived its function is a hole in the check rather
+    than a harmless leftover: it covers whatever is written under that name
+    next. Say so instead of carrying it."""
+
+    seen = set()
+
+    for path in paths:
+        text = pathlib.Path(path).read_text()
+        seen.update(name for name, _, _ in functions(text))
+
+    return sorted(CALLED_LOCKED - seen)
+
+
 def main(argv):
     paths = argv[1:] or sorted(str(p) for p in pathlib.Path("src").glob("*.c"))
 
@@ -157,6 +173,13 @@ def main(argv):
         return 2
 
     total = 0
+
+    # a single file on the command line cannot tell what the tree holds
+    if len(argv) == 1:
+        for name in stale(paths):
+            print("util/lockcheck.py: stale: %s() is listed as called with "
+                  "the mutex held but no longer exists" % name)
+            total += 1
 
     for path in paths:
         for line, kind, message in check(path):

--- a/util/lockcheck.py
+++ b/util/lockcheck.py
@@ -111,13 +111,30 @@ def check(path):
                 given = max(n for n, line in enumerate(body) if UNLOCK in line)
 
                 for n in range(taken, given):
-                    if not re.search(r"\breturn\b", body[n]):
-                        continue
+                    if re.search(r"\breturn\b", body[n]):
+                        if UNLOCK in "\n".join(body[max(0, n - WINDOW):n]):
+                            continue
 
-                    if UNLOCK not in "\n".join(body[max(0, n - WINDOW):n]):
                         findings.append((start + n, "held",
                                          "%s() returns while holding the mutex"
                                          % name))
+                        continue
+
+                    # a goto is safe when its label is inside the region too,
+                    # which is how limit.c and variables.c converge on one exit
+                    m = re.search(r"\bgoto\s+([A-Za-z_][A-Za-z0-9_]*)", body[n])
+
+                    if m is None:
+                        continue
+
+                    label = re.compile(r"^\s*%s\s*:" % re.escape(m.group(1)))
+
+                    if any(label.match(l) for l in body[taken:given]):
+                        continue
+
+                    findings.append((start + n, "held",
+                                     "%s() jumps out of the region holding the "
+                                     "mutex" % name))
 
         if name in CALLED_LOCKED or LOCK in joined:
             continue

--- a/util/lockcheck.py
+++ b/util/lockcheck.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+# @file:    lockcheck.py
+# @brief:   reads the sources for two mistakes around the mutex of the zone
+# @author:  Y.Horie
+
+"""Reports two things the compiler does not.
+
+held
+    a return between taking the mutex of the shared zone and giving it back.
+    ngx_shmtx_lock() is not recursive, so a worker that returns holding it
+    spins for ever on its next request and answers nothing more.
+
+naked
+    a function that searches the tree without taking the mutex. Every reader
+    of the tree takes it -- shm_add_node(), the $vts_ variables, the limit
+    handler, the display handlers -- and one that does not can read a node
+    while another worker frees it.
+
+Neither shows up in a test run unless the timing is right, and neither is
+visible to a sanitizer: nginx workers are processes rather than threads, and
+the nodes come from ngx_slab_alloc() rather than malloc.
+
+    usage: python3 util/lockcheck.py [file ...]
+
+With no argument it reads src/*.c relative to the working directory. It exits
+non zero when it has something to say.
+"""
+
+import pathlib
+import re
+import sys
+
+LOCK = "ngx_shmtx_lock"
+UNLOCK = "ngx_shmtx_unlock"
+
+SEARCHES_THE_TREE = (
+    "ngx_http_vhost_traffic_status_find_node(",
+    "ngx_http_vhost_traffic_status_node_lookup(",
+)
+
+# Functions whose caller has already taken the mutex. Each one was read to
+# check that, and the reason is next to it; a new entry needs the same.
+CALLED_LOCKED = {
+    # the search itself, and the callers of these are what the check is about
+    "ngx_http_vhost_traffic_status_find_node",
+    "ngx_http_vhost_traffic_status_node_lookup",
+
+    # display_handler_control() holds the mutex across the whole dispatch
+    "ngx_http_vhost_traffic_status_node_status_zone",
+    "ngx_http_vhost_traffic_status_node_delete_zone",
+    "ngx_http_vhost_traffic_status_node_reset_zone",
+
+    # display_handler_default() holds it while it writes the body
+    "ngx_http_vhost_traffic_status_display_set_upstream_group",
+}
+
+# how far back to look for the unlock that belongs to a return
+WINDOW = 3
+
+
+def functions(text):
+    """Yields (name, first line number, body lines) for each function."""
+
+    lines = text.splitlines()
+    i = 0
+
+    while i < len(lines):
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*\(", lines[i])
+
+        if m and i and lines[i - 1].strip() and not lines[i - 1].startswith(" "):
+            name = m.group(1)
+
+            j = i
+            while j < len(lines) and not lines[j].startswith("{"):
+                j += 1
+                if j - i > 12:
+                    break
+
+            if j < len(lines) and lines[j].startswith("{"):
+                depth = 0
+                k = j
+
+                while k < len(lines):
+                    depth += lines[k].count("{") - lines[k].count("}")
+                    if depth == 0:
+                        break
+                    k += 1
+
+                yield name, i + 1, lines[i:k + 1]
+                i = k
+
+        i += 1
+
+
+def check(path):
+    findings = []
+    text = pathlib.Path(path).read_text()
+
+    for name, start, body in functions(text):
+        joined = "\n".join(body)
+
+        if LOCK in joined:
+            taken = next(n for n, line in enumerate(body) if LOCK in line)
+
+            if UNLOCK not in joined:
+                findings.append((start + taken, "held",
+                                 "%s() takes the mutex and never gives it back"
+                                 % name))
+            else:
+                given = max(n for n, line in enumerate(body) if UNLOCK in line)
+
+                for n in range(taken, given):
+                    if not re.search(r"\breturn\b", body[n]):
+                        continue
+
+                    if UNLOCK not in "\n".join(body[max(0, n - WINDOW):n]):
+                        findings.append((start + n, "held",
+                                         "%s() returns while holding the mutex"
+                                         % name))
+
+        if name in CALLED_LOCKED or LOCK in joined:
+            continue
+
+        for n, line in enumerate(body):
+            if any(s in line for s in SEARCHES_THE_TREE):
+                findings.append((start + n, "naked",
+                                 "%s() searches the tree without taking the "
+                                 "mutex" % name))
+                break
+
+    return findings
+
+
+def main(argv):
+    paths = argv[1:] or sorted(str(p) for p in pathlib.Path("src").glob("*.c"))
+
+    if not paths:
+        sys.stderr.write("lockcheck: no source to read\n")
+        return 2
+
+    total = 0
+
+    for path in paths:
+        for line, kind, message in check(path):
+            print("%s:%d: %s: %s" % (path, line, kind, message))
+            total += 1
+
+    print("%d finding(s)" % total)
+
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Why

#355 was a reader of the tree that did not take the mutex of the zone, and
nothing in the build or the test run said so.

Nothing could. nginx workers are processes rather than threads, so
ThreadSanitizer does not follow them, and the nodes come from
`ngx_slab_alloc()` rather than malloc, so AddressSanitizer does not watch
them either. A test catches a race only when the timing is right, which it
usually is not — that is why #363 went in without a failing test to lead it.

Reading the sources does catch it, before anything is built.

## What it reports

**naked** — a function that searches the tree without taking the mutex. Every
reader takes it: `shm_add_node()`, the `$vts_` variables, the limit handler,
the display handlers. One that does not can read a node while another worker
hands it back to the slab.

On the tree as it was before #363:

```
src/ngx_http_vhost_traffic_status_set.c:343: naked:
    ngx_http_vhost_traffic_status_set_by_filter_node() searches the tree
    without taking the mutex
```

On master, nothing.

**held** — a return between taking the mutex and giving it back.
`ngx_shmtx_lock()` is not recursive, so a worker that does this spins for
ever on its next attempt and answers nothing more. Taking the unlock out of
`set_by_filter_node()` two different ways:

```
held: set_by_filter_node() returns while holding the mutex
held: set_by_filter_node() takes the mutex and never gives it back
```

## The list in the script

Six functions search the tree without taking the mutex because their caller
holds it already — the three zone commands of the control handler, which
`display_handler_control()` wraps, `display_set_upstream_group()`, which
`display_handler_default()` wraps, and the two search primitives themselves.
Each is in the script with the reason beside it. I read every one of them
rather than adding it to quieten the output.

## What it does not do

It is a heuristic over the text and it does not follow calls between
functions, so a caller that takes the mutex on behalf of a callee that walks
the tree will not be seen; that is what the list above is for, and it needs
an entry when such a pair appears.

It also says nothing about a node read after it has been freed, which is a
run time state — #362 stays out of its reach.

Nothing in `src/` changes, and the job is one step:

```yaml
  lockcheck:
    steps:
      - run: python3 util/lockcheck.py
```
