### PR TITLE
Take out the per type node cache

### DIFF
--- a/src/ngx_http_vhost_traffic_status_limit.c
+++ b/src/ngx_http_vhost_traffic_status_limit.c
@@ -119,7 +119,6 @@ ngx_http_vhost_traffic_status_limit_handler_traffic(ngx_http_request_t *r,
                 continue;
             }
 
-            vtscf->node_caches[type] = node;
 
             vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
@@ -141,7 +140,6 @@ ngx_http_vhost_traffic_status_limit_handler_traffic(ngx_http_request_t *r,
                 continue;
             }
 
-            vtscf->node_caches[type] = node;
 
             vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -1014,14 +1014,6 @@ ngx_http_vhost_traffic_status_create_loc_conf(ngx_conf_t *cf)
     conf->bypass_stats = NGX_CONF_UNSET;
     conf->stats_by_upstream = NGX_CONF_UNSET;
 
-    conf->node_caches = ngx_pcalloc(cf->pool, sizeof(ngx_rbtree_node_t *)
-                                    * (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG + 1));
-    conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_NO] = NULL;
-    conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA] = NULL;
-    conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG] = NULL;
-    conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC] = NULL;
-    conf->node_caches[NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG] = NULL;
-
     return conf;
 }
 

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -361,7 +361,6 @@ typedef struct {
     ngx_flag_t                              stats_by_upstream;
     ngx_uint_t                              ignore_status;
 
-    ngx_rbtree_node_t                     **node_caches;
 } ngx_http_vhost_traffic_status_loc_conf_t;
 
 

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -99,13 +99,11 @@ ngx_rbtree_node_t *
 ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
     ngx_str_t *key, unsigned type, uint32_t key_hash)
 {
-    uint32_t                                   hash;
-    ngx_rbtree_node_t                         *node;
-    ngx_http_vhost_traffic_status_ctx_t       *ctx;
-    ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
+    uint32_t                              hash;
+    ngx_rbtree_node_t                    *node;
+    ngx_http_vhost_traffic_status_ctx_t  *ctx;
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
-    vtscf = ngx_http_get_module_loc_conf(r, ngx_http_vhost_traffic_status_module);
 
     hash = key_hash;
 
@@ -113,16 +111,7 @@ ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
         hash = ngx_crc32_short(key->data, key->len);
     }
 
-    if (vtscf->node_caches[type] != NULL) {
-        if (vtscf->node_caches[type]->key == hash) {
-            node = vtscf->node_caches[type];
-            goto found;
-        }
-    }
-
     node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, key, hash);
-
-found:
 
     return node;
 }

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -239,8 +239,6 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         break;
     }
 
-    vtscf->node_caches[type] = node;
-
     ngx_shmtx_unlock(&shpool->mutex);
 
     return NGX_OK;

--- a/src/ngx_http_vhost_traffic_status_variables.c
+++ b/src/ngx_http_vhost_traffic_status_variables.c
@@ -178,7 +178,6 @@ not_found:
 
 done:
 
-    vtscf->node_caches[type] = node;
 
     ngx_shmtx_unlock(&shpool->mutex);
 

--- a/t/035.node_cache_key.t
+++ b/t/035.node_cache_key.t
@@ -1,0 +1,50 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# find_node() kept the last node it had handed out for a type and gave it back
+# whenever the hash matched, and the hash was the whole test: node->key is a
+# crc32 and the key itself was never looked at. The lookup under it compares
+# both, so two zones whose keys collide on crc32 shared one node and the
+# traffic of one was counted against the other.
+#
+# The two values below collide as filter keys, "FG" 0x1f "g::" 0x1f value:
+#
+#     crc32("FG\x1fg::\x1fkil87gsgjv") == crc32("FG\x1fg::\x1f644iob976g")
+#                                      == 0x02d2be96
+#
+# One request each, and the display has to hold both of them.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each(1) * blocks() * 8;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: two keys that share a hash keep their own nodes
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_by_set_key $arg_z g::;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        vhost_traffic_status_bypass_stats on;
+    }
+    location /c {
+        return 200 "ok\n";
+    }
+--- request eval
+[
+    'GET /c?z=kil87gsgjv',
+    'GET /c?z=644iob976g',
+    'GET /status/format/json',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'ok',
+    'ok',
+    qr/"kil87gsgjv"/,
+    qr/"644iob976g"/,
+]


### PR DESCRIPTION
Fixes #366. Fixes #362.

## The cache

`ngx_http_vhost_traffic_status_find_node()` keeps the last node it handed out
per type and gives it back on a hash match:

```c
    if (vtscf->node_caches[type] != NULL) {
        if (vtscf->node_caches[type]->key == hash) {
            node = vtscf->node_caches[type];
            goto found;
        }
    }

    node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, key, hash);
```

Two things are wrong with those lines.

**It compares a hash and nothing else.** `node->key` is a crc32; the lookup
under it compares the key as well, with `ngx_memn2cmp`. So two zones whose
keys collide share a node and one reports the traffic of the other. Two
requests are enough — no race, no eviction, no `cmd=delete`. That is #366,
and `t/035` is those two requests.

**It is never cleared when the node is freed.** The eviction of
`vhost_traffic_status_filter_max_node` and the three delete paths of the
control handler hand a node back to the slab while every worker that cached
it keeps the pointer. That is #362.

## The fix

Take the cache out. Comparing the key as well as the hash is what the lookup
already does, so a cache that is correct is the lookup; and with no cache
there is nothing to invalidate when a node is freed, which is what made #362
awkward — the cache lives in the location configuration, one copy per worker,
so the worker doing the freeing could only ever clear its own.

## Where it came from

It is an optimisation from 2015 whose correctness check was tightened once
and never finished.

It began with no check at all — whatever node was cached was the node the
request was counted against:

```c
    if (vtscf->vtsn_upstream) {
        ngx_shmtx_lock(&shpool->mutex);
        ngx_vhost_traffic_status_node_set(r, vtscf->vtsn_upstream);
```

04d4f26, March 2015, added the hash. Its subject says what it was for:

> Bugfix: added compare upstream hash. It does not updated upstream peers
> status so I have fixed it.

```diff
-    if (vtscf->vtsn_upstream) {
+    if (vtscf->vtsn_upstream && vtscf->vtsn_hash == hash) {
```

So the hash comparison was itself the fix for peers being counted against
each other. It went from no check to a hash and stopped there, one step
short of the key.

e12984d, November 2015, folded `vtsn_server`, `vtsn_upstream` and
`vtsn_cache` into `node_caches[]` per type and carried the same test over.
`ngx_http_vhost_traffic_status_node_lookup()` has compared the key the
whole time; only the cache in front of it has not.

## What it costs

Nothing I can measure. It saved one tree walk when the same type was looked
up twice in a request, and the walk is short. A tree of 400 filter nodes,
four workers, `ab -k -c 32`:

| | |
| --- | --- |
| with the cache | 153185 req/s |
| without it | 156110 req/s |

## Test first

The first commit is `t/035` on its own. The two values in it collide as
filter keys:

```
crc32("FG\x1fg::\x1fkil87gsgjv") == crc32("FG\x1fg::\x1f644iob976g")
                                 == 0x02d2be96
```

It fails on master and passes with the second commit. The rest of the suite
gives the same results either way.

The pair was found by hashing random names; keys that differ in a short run
of bytes never collide, since crc32 catches every burst that short. Eight
million names of the form `h1.test`, `h2.test` gave nothing, while random
ones collided after 59435.
