### PR TITLE
Read the sizes of the cache zone outside our own mutex

### DIFF
--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -15,8 +15,11 @@ static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_re
     ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init);
 
 #if (NGX_HTTP_CACHE)
+static void ngx_http_vhost_traffic_status_shm_get_cache_size(ngx_http_request_t *r,
+    ngx_atomic_uint_t *max_size, ngx_atomic_uint_t *used_size);
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init);
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init,
+    ngx_atomic_uint_t max_size, ngx_atomic_uint_t used_size);
 #endif
 
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_filter_node(ngx_http_request_t *r,
@@ -111,6 +114,9 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
     ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
+#if (NGX_HTTP_CACHE)
+    ngx_atomic_uint_t                          cache_max_size, cache_used_size;
+#endif
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
 
@@ -136,6 +142,18 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
     /* the hash does not touch the shared memory, keep it out of the lock */
     hash = ngx_crc32_short(key->data, key->len);
+
+#if (NGX_HTTP_CACHE)
+    cache_max_size = 0;
+    cache_used_size = 0;
+
+    /* the sizes come from the zone of the cache, which has a mutex of its own */
+
+    if (type == NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC) {
+        ngx_http_vhost_traffic_status_shm_get_cache_size(r, &cache_max_size,
+                                                         &cache_used_size);
+    }
+#endif
 
     ngx_shmtx_lock(&shpool->mutex);
 
@@ -231,7 +249,8 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
 #if (NGX_HTTP_CACHE)
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_CC:
-        (void) ngx_http_vhost_traffic_status_shm_add_node_cache(r, vtsn, init);
+        (void) ngx_http_vhost_traffic_status_shm_add_node_cache(r, vtsn, init,
+                   cache_max_size, cache_used_size);
         break;
 #endif
 
@@ -287,23 +306,25 @@ ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
 
 #if (NGX_HTTP_CACHE)
 
-static ngx_int_t
-ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init)
+static void
+ngx_http_vhost_traffic_status_shm_get_cache_size(ngx_http_request_t *r,
+    ngx_atomic_uint_t *max_size, ngx_atomic_uint_t *used_size)
 {
     ngx_http_cache_t       *c;
     ngx_http_upstream_t    *u;
     ngx_http_file_cache_t  *cache;
 
+    *max_size = 0;
+    *used_size = 0;
+
     u = r->upstream;
 
-    if (u != NULL && u->cache_status != 0 && r->cache != NULL) {
-        c = r->cache;
-        cache = c->file_cache;
-
-    } else {
-        return NGX_OK;
+    if (u == NULL || u->cache_status == 0 || r->cache == NULL) {
+        return;
     }
+
+    c = r->cache;
+    cache = c->file_cache;
 
     /*
      * If max_size in proxy_cache_path directive is not specified,
@@ -318,15 +339,41 @@ ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
      *         cache->max_size
      */
 
+    *max_size = (ngx_atomic_uint_t) (cache->max_size * cache->bsize);
+
+    /*
+     * This reads the zone of the cache, which has a mutex of its own, so the
+     * caller asks for the sizes before it takes the mutex of the traffic zone.
+     * Taking one while holding the other puts an order on two locks that
+     * nothing else agrees on, and it holds ours for the length of that read.
+     */
+
+    ngx_shmtx_lock(&cache->shpool->mutex);
+
+    *used_size = (ngx_atomic_uint_t) (cache->sh->size * cache->bsize);
+
+    ngx_shmtx_unlock(&cache->shpool->mutex);
+}
+
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_shm_add_node_cache(ngx_http_request_t *r,
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init,
+    ngx_atomic_uint_t max_size, ngx_atomic_uint_t used_size)
+{
+    ngx_http_upstream_t  *u;
+
+    u = r->upstream;
+
+    if (u == NULL || u->cache_status == 0 || r->cache == NULL) {
+        return NGX_OK;
+    }
+
     if (init == NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_NONE) {
-        vtsn->stat_cache_max_size = (ngx_atomic_uint_t) (cache->max_size * cache->bsize);
+        vtsn->stat_cache_max_size = max_size;
 
     } else {
-        ngx_shmtx_lock(&cache->shpool->mutex);
-
-        vtsn->stat_cache_used_size = (ngx_atomic_uint_t) (cache->sh->size * cache->bsize);
-
-        ngx_shmtx_unlock(&cache->shpool->mutex);
+        vtsn->stat_cache_used_size = used_size;
     }
 
     return NGX_OK;


### PR DESCRIPTION
Taken from #344 by @yaoge123, which carries this together with two other
changes. This is the one that stands on its own; the other two are discussed
below.

## The nesting

`shm_add_node_cache()` runs inside the mutex of the traffic zone and takes the
mutex of the cache zone within it:

```c
    /* shm_add_node() holds shpool->mutex here */
    ngx_shmtx_lock(&cache->shpool->mutex);

    vtsn->stat_cache_used_size = (ngx_atomic_uint_t) (cache->sh->size * cache->bsize);

    ngx_shmtx_unlock(&cache->shpool->mutex);
```

Two things are wrong with that. It puts an order on two locks that nothing
else agrees on, so anything that ever takes them the other way round has a
cycle. And it holds ours across a read that has nothing to do with the tree,
which every other worker waiting on the zone pays for.

I have not found a path in nginx that takes them in the reverse order — the
cache manager takes the cache zone and never touches ours — so the deadlock
is a shape rather than something I can reproduce. The hold time is real
either way.

## The change

Ask the cache zone for its sizes before taking our mutex, and hand them to
the node update, which then takes no lock:

```
before  our mutex → shm_add_node_cache() → cache mutex        (nested)
after   cache mutex → our mutex → shm_add_node_cache()        (no lock)
```

The read is only done for a cache node, so a server, upstream or filter
request does not pay for it.

The comment about `max_size` and `keys_zone` moves with the code that reads
them.

## Behaviour

Six misses and six hits through a `proxy_cache`, before and after:

| | |
| --- | --- |
| `maxSize` | 10485760 |
| `usedSize` | 24576 |
| `inBytes` | 876 |
| `outBytes` | 25800 |
| responses | miss=6 hit=6 |

Identical. The whole test suite gives the same results as master, and it
builds both with the cache and with `--without-http_cache`.

#344 does not build without the cache. Its cache declarations are correctly
guarded; what sits outside the `#if` is `ngx_int_t rc;`, used only within it:

```
ngx_http_vhost_traffic_status_shm.c:93:48:
  error: unused variable 'rc' [-Werror,-Wunused-variable]
```

The getter here returns `void` — it has nothing to report that the zeroed
sizes do not already say — so there is no `rc` to leave unguarded.

## On not adding a test

Nothing observable changes here, so there is no test that fails before and
passes after. What I did check is whether the existing ones would notice if
the refactor were wrong: stubbing the new read out, so that the node is
handed zeroes, fails four subtests of `t/021` and ten of `t/025`. The sizes
are covered, and by more than their presence.

## The other two changes in #344

**The `r->upstream` NULL check.** I could not find the state it guards
against. `r->upstream_states` is only filled from inside upstream processing,
which runs after `ngx_http_upstream_create()` has set `r->upstream`, and
nothing in nginx sets it back to NULL — the only `upstream = NULL` in the
tree are `u->pipe->upstream` and configuration defaults. `ngx_http_subrequest()`
does not carry `upstream_states` over, and `NGX_HTTP_SUBREQUEST_CLONE` copies
the method, the location configuration and the phase handler but not those.
The check is harmless and I am happy to take it as a guard, but not as a
crash fix, so it belongs in its own pull request with that framing.

**The subrequest guard.** `ngx_http_finalize_request()` only logs a
subrequest when the location has `log_subrequest on`:

```c
    if (r == c->data || r->background) {
        if (!r->logged) {
            clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
            if (clcf->log_subrequest) {
                ngx_http_log_request(r);
            }
```

So the LOG phase handler of this module is reached for a subrequest only
where that is switched on, and a guard on `r != r->main` overrides that
setting rather than complementing it. The one in `set.c` is unreachable:
`ngx_http_core_access_phase()` skips subrequests before any handler runs.
Whether this module should count subrequests at all is worth settling on its
own, so I will open an issue for it rather than decide it here.
