### PR TITLE
Test r->upstream before reading through it

### DIFF
--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -497,7 +497,7 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
     ngx_http_upstream_main_conf_t  *umcf;
 
     if (r->upstream_states == NULL || r->upstream_states->nelts == 0
-        || r->upstream->state == NULL)
+        || r->upstream == NULL || r->upstream->state == NULL)
     {
         return NGX_OK;
     }


### PR DESCRIPTION
Taken from #344 by @yaoge123, split out so it can be judged on its own.

## The change

```diff
     if (r->upstream_states == NULL || r->upstream_states->nelts == 0
-        || r->upstream->state == NULL)
+        || r->upstream == NULL || r->upstream->state == NULL)
```

The condition reads through `r->upstream` while testing `r->upstream_states`.

## What it is not

#344 carries this as a P0 crash fix, with a subrequest that has
`r->upstream_states` set while `r->upstream` is NULL. I went looking for that
state and could not find it:

- `r->upstream_states` is filled in `ngx_http_upstream_init_request()` and in
  `ngx_http_upstream_next()`, both of which run after
  `ngx_http_upstream_create()` has set `r->upstream`
- nothing in nginx sets `r->upstream` back to NULL; the only `upstream = NULL`
  in the tree are `u->pipe->upstream` and configuration defaults, and the same
  holds across the modules bundled with OpenResty
- `ngx_http_subrequest()` does not carry `upstream_states` over to the
  subrequest, and `NGX_HTTP_SUBREQUEST_CLONE` copies the method, the location
  configuration and the phase handler but not those

So I am proposing it as a guard on a line that dereferences a pointer it has
not tested, not as a fix for a crash I can reproduce. If the report in #344 is
a real crash, the cause is elsewhere and this would only have hidden it.

The whole test suite gives the same results as master.
