### PR TITLE
test: write the exec() fallback as an alternative, not the next statement

### DIFF
--- a/t/028.upstream_resolve.t
+++ b/t/028.upstream_resolve.t
@@ -69,9 +69,11 @@ if ($dns_pid == 0) {
     my $server = __FILE__;
     $server =~ s{[^/]+$}{dns_server.pl};
 
-    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr);
-
-    POSIX::_exit(1);
+    # the _exit() is the path where exec() itself failed; writing it as the
+    # alternative rather than the next statement is also what keeps perl from
+    # warning that it is unlikely to be reached
+    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
+        or POSIX::_exit(1);
 }
 
 END {


### PR DESCRIPTION
Compiling `t/028.upstream_resolve.t` prints:

```
Statement unlikely to be reached at t/028.upstream_resolve.t line 74.
    (Maybe you meant system() when you said exec()?)
```

perl issues that whenever a statement follows `exec()`, on the reasoning that
a successful `exec()` replaces the process and never returns.

Here the following statement is the point. It is the path where `exec()`
itself failed — a missing interpreter, a missing `dns_server.pl` — and
without it the forked child would fall through and run the test script a
second time. So the warning is about the one case the line exists for.

Writing the fallback as the alternative rather than the next statement says
that directly, and is what `perldoc -f exec` suggests for the warning:

```perl
    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
        or POSIX::_exit(1);
```

Checked that the path still does its job — `exec()` of a program that does
not exist returns false, and the child exits 1 rather than carrying on:

```
Can't exec "/nonexistent/definitely-not-here": No such file or directory
child exit status = 1
```

`perl -c` on the file is clean afterwards, and the test passes. It was the
only compile warning in `t/`.
