### PR TITLE
ci: build against nginx 1.30.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: nginx/nginx
           path: nginx
-          ref: 'a92a537860c7b87d3793d9eb41c9cf3ed833b53c'
+          ref: '017cf98dcce217946572a896f0992370475e189f'
       - name: 'checkout freenginx'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,7 +134,7 @@ jobs:
         with:
           repository: nginx/nginx
           path: nginx
-          ref: 'a92a537860c7b87d3793d9eb41c9cf3ed833b53c'
+          ref: '017cf98dcce217946572a896f0992370475e189f'
       - name: 'prepare cpanm'
         run: |
           sudo apt install -y cpanminus
@@ -215,7 +215,7 @@ jobs:
         with:
           repository: nginx/nginx
           path: nginx
-          ref: 'a92a537860c7b87d3793d9eb41c9cf3ed833b53c'
+          ref: '017cf98dcce217946572a896f0992370475e189f'
       - name: 'build nginx'
         working-directory: nginx
         run: |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ the test requires Nginx to listen on port 80.
 
 ## Compatibility
 * Nginx
-  * 1.30.x (last tested: 1.30.2)
+  * 1.30.x (last tested: 1.30.4)
   * 1.27.x (last tested: 1.27.3)
   * 1.22.x (last tested: 1.22.0)
   * 1.19.x (last tested: 1.19.6)


### PR DESCRIPTION
The stable branch has moved twice since the pin was set. `a92a537` is
`nginx-1.30.2-RELEASE`; `017cf98` is `nginx-1.30.4-RELEASE`, tagged
2026-07-15. Three jobs check out the same ref, so all three move together.

`README.md` says 1.30.4 for the same reason it said 1.30.2 — the compatibility
list records what CI actually tests.

## Checked before moving the pin

The module builds against 1.30.4 with no warnings and reports itself:

```
moduleVersion = v0.2.7   nginxVersion = 1.30.4
```

The suite gives the same verdicts, file for file:

```
1.30.2   PASS=24 FAIL=12
1.30.4   PASS=24 FAIL=12   (the same twelve files)
```

Those twelve want an nginx on port 80, which `sudo prove -r t` provides in CI
and which a local run without it cannot; they are the same twelve on both
versions, so there is nothing version-specific in them.

`check_1.20.1+.patch` of nginx_upstream_check_module still applies cleanly to
1.30.4 — the build job patches nginx with it before configuring, so a rejected
hunk there would have broken the job.

## What stays

The comment in the asan job about leaving `nonnull-attribute` out is still
accurate: 1.30.4 does not carry `b0a4d0fb82` either, so the exclusion is still
needed while the tests build a stable release.

The freenginx ref is a separate pin and is untouched.
