### PR TITLE
Delete the nodes that have not been used for a while

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ It is able to reset or delete traffic zones through a query string.
 The request responds with a JSON document.
 
 * URI Syntax
-  * /*`{status_uri}`*/control?cmd=*`{command}`*&group=*`{group}`*&zone=*`{name}`*
+  * /*`{status_uri}`*/control?cmd=*`{command}`*&group=*`{group}`*&zone=*`{name}`*\[&expire=*`{seconds}`*\]
 
 ```Nginx
 http {
@@ -467,6 +467,16 @@ The available request arguments are as follows:
     * It reset traffic zones without deleting nodes in shared memory.(= init to 0)
   * delete
     * It delete traffic zones in shared memory. when re-request recreated. 
+* **expire**=\<`seconds`\>
+  * Only with `delete`. Among the zones that `group` and `zone` already select,
+    it deletes the ones whose last request is older than the given number of
+    seconds, and leaves the rest. Without it every selected zone is deleted, as
+    before. `processingCounts` in the response says how many were deleted.
+  * A value that is not a number leaves the request undone rather than falling
+    back to deleting everything selected.
+  * The age of a zone is kept as a timestamp in milliseconds. On a 32 bit build
+    that count wraps every 49.7 days, which is the largest `expire` that is
+    meaningful there.
 * **group**=\<`server`\|`filter`\|`upstream@alone`\|`upstream@group`\|`cache`\|`*`\>
   * server
   * filter
@@ -569,6 +579,24 @@ It delete the specified zones in shared memory.
   * /status/control?cmd=delete&group=upstream@alone&zone=*
 * cacheZones
   * /status/control?cmd=delete&group=cache&zone=*
+
+#### To delete only the zones that have not been used for a while
+Nodes are not freed when an upstream goes away, so a zone that sees a lot of
+upstreams appear and disappear fills up and then refuses every new node. This
+deletes what has gone quiet and keeps what is still in use. It works on a zone
+that is already full, so it is also the way out of that state.
+
+* everything not requested for an hour
+  * /status/control?cmd=delete&group=*&zone=*&expire=3600
+* upstream peers not requested for a day
+  * /status/control?cmd=delete&group=upstream@group&zone=*&expire=86400
+
+Nothing calls this on its own; drive it from cron or from whatever watches
+`freeSize` in `sharedZones`.
+
+Note that a zone restored from a dump carries the timestamps it had when the
+dump was written, so after a long shutdown everything looks old and a sweep
+straight afterwards empties it.
 
 #### To delete each zones
 * single zone in serverZones

--- a/README.md
+++ b/README.md
@@ -467,16 +467,20 @@ The available request arguments are as follows:
     * It reset traffic zones without deleting nodes in shared memory.(= init to 0)
   * delete
     * It delete traffic zones in shared memory. when re-request recreated. 
-* **expire**=\<`seconds`\>
+* **expire**=\<`time`\>
   * Only with `delete`. Among the zones that `group` and `zone` already select,
-    it deletes the ones whose last request is older than the given number of
-    seconds, and leaves the rest. Without it every selected zone is deleted, as
-    before. `processingCounts` in the response says how many were deleted.
-  * A value that is not a number leaves the request undone rather than falling
+    it deletes the ones whose last request is older than the time given, and
+    leaves the rest. Without it every selected zone is deleted, as before.
+    `processingCounts` in the response says how many were deleted.
+  * The time is written the way it is written in the configuration: a bare
+    number is seconds, and `1h`, `30m`, `7d` say the same thing shorter.
+    `expire=0` selects everything, which is what leaving it out already does.
+  * A value that cannot be read leaves the request undone rather than falling
     back to deleting everything selected.
   * The age of a zone is kept as a timestamp in milliseconds. On a 32 bit build
-    that count wraps every 49.7 days, which is the largest `expire` that is
-    meaningful there.
+    that count wraps every 49.7 days, so a zone left untouched for longer than
+    that can read as more recent than it is and be missed by one sweep. It is
+    never deleted early.
 * **group**=\<`server`\|`filter`\|`upstream@alone`\|`upstream@group`\|`cache`\|`*`\>
   * server
   * filter
@@ -587,9 +591,11 @@ deletes what has gone quiet and keeps what is still in use. It works on a zone
 that is already full, so it is also the way out of that state.
 
 * everything not requested for an hour
-  * /status/control?cmd=delete&group=*&zone=*&expire=3600
+  * /status/control?cmd=delete&group=*&zone=*&expire=1h
 * upstream peers not requested for a day
-  * /status/control?cmd=delete&group=upstream@group&zone=*&expire=86400
+  * /status/control?cmd=delete&group=upstream@group&zone=*&expire=1d
+* one named zone, only if it has gone quiet
+  * /status/control?cmd=delete&group=filter&zone=*`filter_group`*@*`name`*&expire=7d
 
 Nothing calls this on its own; drive it from cron or from whatever watches
 `freeSize` in `sharedZones`.

--- a/README.md
+++ b/README.md
@@ -477,15 +477,16 @@ The available request arguments are as follows:
     `expire=0` selects everything, which is what leaving it out already does.
   * A value that cannot be read leaves the request undone rather than falling
     back to deleting everything selected.
-  * The age of a zone is the time of the last request this module **recorded**
-    against it, which is not the same as the last request it served.
-    `vhost_traffic_status_ignore_status` suppresses the recording, so a zone
-    whose requests are all excluded by it keeps the age it had before, or none
-    at all if it never had one, and `expire` will read it as idle and delete it
-    while it is still being served.
+  * The age of a zone is the time of the last request it served, which is
+    recorded whether or not the request was counted, so a zone that
+    `vhost_traffic_status_ignore_status` excludes from the figures still
+    counts as in use here.
   * The age is kept as a timestamp in milliseconds. On a 32 bit build that
     count wraps every 49.7 days, so a zone left untouched for longer than that
     can read as more recent than it is and be missed by one sweep.
+  * A zone restored from a dump starts as though it had been reached at the
+    restart rather than when the file was written, so a sweep straight
+    afterwards does not empty what the dump was kept for.
 * **group**=\<`server`\|`filter`\|`upstream@alone`\|`upstream@group`\|`cache`\|`*`\>
   * server
   * filter
@@ -604,10 +605,6 @@ that is already full, so it is also the way out of that state.
 
 Nothing calls this on its own; drive it from cron or from whatever watches
 `freeSize` in `sharedZones`.
-
-Note that a zone restored from a dump carries the timestamps it had when the
-dump was written, so after a long shutdown everything looks old and a sweep
-straight afterwards empties it.
 
 #### To delete each zones
 * single zone in serverZones

--- a/README.md
+++ b/README.md
@@ -477,10 +477,15 @@ The available request arguments are as follows:
     `expire=0` selects everything, which is what leaving it out already does.
   * A value that cannot be read leaves the request undone rather than falling
     back to deleting everything selected.
-  * The age of a zone is kept as a timestamp in milliseconds. On a 32 bit build
-    that count wraps every 49.7 days, so a zone left untouched for longer than
-    that can read as more recent than it is and be missed by one sweep. It is
-    never deleted early.
+  * The age of a zone is the time of the last request this module **recorded**
+    against it, which is not the same as the last request it served.
+    `vhost_traffic_status_ignore_status` suppresses the recording, so a zone
+    whose requests are all excluded by it keeps the age it had before, or none
+    at all if it never had one, and `expire` will read it as idle and delete it
+    while it is still being served.
+  * The age is kept as a timestamp in milliseconds. On a 32 bit build that
+    count wraps every 49.7 days, so a zone left untouched for longer than that
+    can read as more recent than it is and be missed by one sweep.
 * **group**=\<`server`\|`filter`\|`upstream@alone`\|`upstream@group`\|`cache`\|`*`\>
   * server
   * filter

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -394,7 +394,6 @@ ngx_http_vhost_traffic_status_node_expire_match(
     ngx_http_vhost_traffic_status_control_t *control,
     ngx_http_vhost_traffic_status_node_t *vtsn)
 {
-    ngx_int_t   i;
     ngx_msec_t  last;
 
     /* nothing was asked for, so every node the selection matches is taken */
@@ -403,8 +402,7 @@ ngx_http_vhost_traffic_status_node_expire_match(
         return NGX_OK;
     }
 
-    i = ngx_http_vhost_traffic_status_node_time_queue_rear(&vtsn->stat_request_times);
-    last = vtsn->stat_request_times.times[i].time;
+    last = vtsn->stat_last_seen;
 
     /*
      * The stored value is the epoch in milliseconds. ngx_msec_t is as wide as

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -20,6 +20,9 @@ static void ngx_http_vhost_traffic_status_node_status_zone(
 static ngx_int_t ngx_http_vhost_traffic_status_node_delete_get_nodes(
     ngx_http_vhost_traffic_status_control_t *control,
     ngx_array_t **nodes, ngx_rbtree_node_t *node);
+static ngx_int_t ngx_http_vhost_traffic_status_node_expire_match(
+    ngx_http_vhost_traffic_status_control_t *control,
+    ngx_http_vhost_traffic_status_node_t *vtsn);
 static void ngx_http_vhost_traffic_status_node_delete_all(
     ngx_http_vhost_traffic_status_control_t *control);
 static void ngx_http_vhost_traffic_status_node_delete_group(
@@ -387,6 +390,40 @@ ngx_http_vhost_traffic_status_node_status(
 
 
 static ngx_int_t
+ngx_http_vhost_traffic_status_node_expire_match(
+    ngx_http_vhost_traffic_status_control_t *control,
+    ngx_http_vhost_traffic_status_node_t *vtsn)
+{
+    ngx_int_t   i;
+    ngx_msec_t  last;
+
+    /* nothing was asked for, so every node the selection matches is taken */
+
+    if (control->expire == 0) {
+        return NGX_OK;
+    }
+
+    i = ngx_http_vhost_traffic_status_node_time_queue_rear(&vtsn->stat_request_times);
+    last = vtsn->stat_request_times.times[i].time;
+
+    /*
+     * The stored value is the epoch in milliseconds. ngx_msec_t is as wide as
+     * a pointer, so on a 32 bit build it wraps every 49.7 days; taking the
+     * difference in that same unsigned type stays right across the wrap,
+     * which is also what limits how large an expire can usefully be.
+     */
+
+    if ((ngx_msec_t) (ngx_http_vhost_traffic_status_current_msec() - last)
+        > control->expire)
+    {
+        return NGX_OK;
+    }
+
+    return NGX_DECLINED;
+}
+
+
+static ngx_int_t
 ngx_http_vhost_traffic_status_node_delete_get_nodes(
     ngx_http_vhost_traffic_status_control_t *control,
     ngx_array_t **nodes, ngx_rbtree_node_t *node)
@@ -401,8 +438,11 @@ ngx_http_vhost_traffic_status_node_delete_get_nodes(
     if (node != ctx->rbtree->sentinel) {
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-        if ((ngx_int_t) vtsn->stat_upstream.type == control->group) {
-
+        if ((control->group == -1
+             || (ngx_int_t) vtsn->stat_upstream.type == control->group)
+            && ngx_http_vhost_traffic_status_node_expire_match(control, vtsn)
+               == NGX_OK)
+        {
             if (*nodes == NULL) {
                 *nodes = ngx_array_create(control->r->pool, 1,
                         sizeof(ngx_http_vhost_traffic_status_delete_t));
@@ -527,6 +567,7 @@ ngx_http_vhost_traffic_status_node_delete_zone(
     ngx_slab_pool_t                           *shpool;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     ctx = ngx_http_get_module_main_conf(control->r, ngx_http_vhost_traffic_status_module);
@@ -545,10 +586,16 @@ ngx_http_vhost_traffic_status_node_delete_zone(
     node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
 
     if (node != NULL) {
-        ngx_rbtree_delete(ctx->rbtree, node);
-        ngx_slab_free_locked(shpool, node);
+        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-        control->count++;
+        if (ngx_http_vhost_traffic_status_node_expire_match(control, vtsn)
+            == NGX_OK)
+        {
+            ngx_rbtree_delete(ctx->rbtree, node);
+            ngx_slab_free_locked(shpool, node);
+
+            control->count++;
+        }
     }
 }
 
@@ -560,7 +607,21 @@ ngx_http_vhost_traffic_status_node_delete(
     switch (control->range) {
 
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_CONTROL_RANGE_ALL:
-        ngx_http_vhost_traffic_status_node_delete_all(control);
+
+        /*
+         * delete_all() empties the tree by taking its root until there is
+         * none, which cannot leave anything behind. With an expire there is
+         * something to leave behind, so the walk that collects what matches
+         * is used instead; it takes every type when the group is -1.
+         */
+
+        if (control->expire) {
+            ngx_http_vhost_traffic_status_node_delete_group(control);
+
+        } else {
+            ngx_http_vhost_traffic_status_node_delete_all(control);
+        }
+
         break;
 
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_CONTROL_RANGE_GROUP:

--- a/src/ngx_http_vhost_traffic_status_control.h
+++ b/src/ngx_http_vhost_traffic_status_control.h
@@ -42,6 +42,7 @@ typedef struct {
     ngx_str_t                   *arg_zone;
     ngx_str_t                   *arg_name;
     ngx_uint_t                   range;
+    ngx_msec_t                   expire;
     ngx_uint_t                   count;
     u_char                     **buf;
 } ngx_http_vhost_traffic_status_control_t;

--- a/src/ngx_http_vhost_traffic_status_display.c
+++ b/src/ngx_http_vhost_traffic_status_display.c
@@ -240,19 +240,27 @@ ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r)
 
         /*
          * expire selects, among what group and zone already match, the nodes
-         * whose last request is older than the given number of seconds. A
-         * value that does not parse leaves the command undone rather than
-         * falling back to deleting everything the selection matches.
+         * whose last request is older than the time given. It is read the way
+         * the configuration reads a time: a bare number is seconds, and 1h or
+         * 30m say the same thing shorter. ngx_parse_time() answers in
+         * milliseconds and refuses what it cannot represent, so there is no
+         * multiplication here left to overflow - on a 32 bit build that used
+         * to turn a large expire into a very small one and take the whole
+         * selection with it.
+         *
+         * A value it refuses leaves the command undone rather than falling
+         * back to deleting everything selected, which is the more expensive
+         * way to be wrong.
          */
 
         if (ngx_http_arg(r, (u_char *) "expire", 6, &arg_expire) == NGX_OK) {
-            expire = ngx_atoi(arg_expire.data, arg_expire.len);
+            expire = ngx_parse_time(&arg_expire, 0);
 
-            if (expire == NGX_ERROR || expire < 0) {
+            if (expire == NGX_ERROR) {
                 control->command = NGX_HTTP_VHOST_TRAFFIC_STATUS_CONTROL_CMD_NONE;
 
             } else {
-                control->expire = (ngx_msec_t) expire * 1000;
+                control->expire = (ngx_msec_t) expire;
             }
         }
 

--- a/src/ngx_http_vhost_traffic_status_display.c
+++ b/src/ngx_http_vhost_traffic_status_display.c
@@ -74,8 +74,8 @@ done:
 static ngx_int_t
 ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r)
 {
-    ngx_int_t                                  size, rc;
-    ngx_str_t                                  type, alpha, encoded_ch, arg_cmd, arg_group, arg_zone;
+    ngx_int_t                                  size, rc, expire;
+    ngx_str_t                                  type, alpha, encoded_ch, arg_cmd, arg_group, arg_zone, arg_expire;
     ngx_buf_t                                 *b;
     ngx_chain_t                                out;
     ngx_slab_pool_t                           *shpool;
@@ -235,6 +235,24 @@ ngx_http_vhost_traffic_status_display_handler_control(ngx_http_request_t *r)
             if (rc != NGX_OK) {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                               "display_handler_control::replace_strc() failed");
+            }
+        }
+
+        /*
+         * expire selects, among what group and zone already match, the nodes
+         * whose last request is older than the given number of seconds. A
+         * value that does not parse leaves the command undone rather than
+         * falling back to deleting everything the selection matches.
+         */
+
+        if (ngx_http_arg(r, (u_char *) "expire", 6, &arg_expire) == NGX_OK) {
+            expire = ngx_atoi(arg_expire.data, arg_expire.len);
+
+            if (expire == NGX_ERROR || expire < 0) {
+                control->command = NGX_HTTP_VHOST_TRAFFIC_STATUS_CONTROL_CMD_NONE;
+
+            } else {
+                control->expire = (ngx_msec_t) expire * 1000;
             }
         }
 

--- a/src/ngx_http_vhost_traffic_status_dump.c
+++ b/src/ngx_http_vhost_traffic_status_dump.c
@@ -311,6 +311,16 @@ ngx_http_vhost_traffic_status_dump_restore_add_node(ngx_event_t *ev,
         vtsn->stat_status_code_counter = NULL;
         vtsn->stat_status_code_length = 0;
 
+        /*
+         * The dump carries when each zone was last reached, which was however
+         * long ago the file was written. Reading it back as it stands would
+         * have the first sweep of an expire take everything the dump exists
+         * to keep, so the zones start again as reached now. It costs them one
+         * expire of life after a restart.
+         */
+
+        vtsn->stat_last_seen = ngx_http_vhost_traffic_status_current_msec();
+
         ngx_memcpy(vtsn->data, key->data, key->len);
 
         ngx_rbtree_insert(ctx->rbtree, node);

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -209,9 +209,7 @@ ngx_rbtree_node_t *
 ngx_http_vhost_traffic_status_find_lru_node_cmp(ngx_http_request_t *r,
     ngx_rbtree_node_t *a, ngx_rbtree_node_t *b)
 {
-    ngx_int_t                                         ai, bi;
-    ngx_http_vhost_traffic_status_node_t             *avtsn, *bvtsn;
-    ngx_http_vhost_traffic_status_node_time_queue_t  *aq, *bq;
+    ngx_http_vhost_traffic_status_node_t  *avtsn, *bvtsn;
 
     if (a == NULL) {
         return b;
@@ -220,21 +218,13 @@ ngx_http_vhost_traffic_status_find_lru_node_cmp(ngx_http_request_t *r,
     avtsn = (ngx_http_vhost_traffic_status_node_t *) &a->color;
     bvtsn = (ngx_http_vhost_traffic_status_node_t *) &b->color;
 
-    aq = &avtsn->stat_request_times;
-    bq = &bvtsn->stat_request_times;
+    /*
+     * This used to read the last entry of the time queue, which a zone whose
+     * statuses ignore_status excludes never fills, so such a zone was always
+     * the one chosen to go however much traffic it was carrying.
+     */
 
-    if (aq->front == aq->rear) {
-        return a;
-    }
-
-    if (bq->front == bq->rear) {
-        return b;
-    }
-
-    ai = ngx_http_vhost_traffic_status_node_time_queue_rear(aq);
-    bi = ngx_http_vhost_traffic_status_node_time_queue_rear(bq);
-
-    return (aq->times[ai].time < bq->times[bi].time) ? a : b;
+    return (avtsn->stat_last_seen < bvtsn->stat_last_seen) ? a : b;
 }
 
 
@@ -292,7 +282,7 @@ ngx_http_vhost_traffic_status_node_zero(ngx_http_vhost_traffic_status_node_t *vt
     vtsn->stat_5xx_counter = 0;
 
     vtsn->stat_request_time_counter = 0;
-    vtsn->stat_request_time = 0;
+    vtsn->stat_last_seen = 0;
     vtsn->stat_upstream.response_time_counter = 0;
     vtsn->stat_upstream.response_time = 0;
 
@@ -336,7 +326,6 @@ ngx_http_vhost_traffic_status_node_zero(ngx_http_vhost_traffic_status_node_t *vt
 
 /*
    Initialize the node and update it with the first request.
-   Set the `stat_request_time` to the time of the first request.
 */
 void
 ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
@@ -359,7 +348,6 @@ ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
 
     /* set serverZone */
     ms = ngx_http_vhost_traffic_status_request_time(r);
-    vtsn->stat_request_time = (ngx_msec_t) ms;
 
     ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot);
 }
@@ -400,6 +388,14 @@ ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot)
 {
     ngx_uint_t status = r->headers_out.status;
+
+    /*
+     * Before the check below: a request whose status is not counted was
+     * served all the same, and what tells the node apart from an abandoned
+     * one is that it was reached, not that it was counted.
+     */
+
+    vtsn->stat_last_seen = ngx_http_vhost_traffic_status_current_msec();
 
     if (ngx_http_vhost_traffic_status_ignore_status(vtsn->ignore_status, status)) {
         return;

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -89,7 +89,21 @@ typedef struct {
     ngx_atomic_t                                           *stat_status_code_counter;
 
     ngx_atomic_t                                           stat_request_time_counter;
-    ngx_msec_t                                             stat_request_time;
+
+    /*
+       When the node was last reached, in milliseconds since the epoch. It is
+       written for every request, before the check that ignore_status makes,
+       so it says when the zone was last served rather than when it was last
+       counted. Nothing else here can stand in for it: the time queue holds
+       what was counted, which is not the same thing, and the readers of it
+       pair each timestamp with a duration.
+
+       It sits where stat_request_time used to. That field held the duration
+       of the first request and nothing read it - the one variable that names
+       it, $vts_request_time, uses the offset to recognise itself and then
+       averages the queue.
+    */
+    ngx_msec_t                                             stat_last_seen;
     ngx_http_vhost_traffic_status_node_time_queue_t        stat_request_times;
     ngx_http_vhost_traffic_status_node_histogram_bucket_t  stat_request_buckets;
 

--- a/src/ngx_http_vhost_traffic_status_variables.c
+++ b/src/ngx_http_vhost_traffic_status_variables.c
@@ -55,9 +55,10 @@ static ngx_http_variable_t  ngx_http_vhost_traffic_status_vars[] = {
       offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_time_counter),
       NGX_HTTP_VAR_NOCACHEABLE, 0 },
 
+    /* the offset names the queue this averages, it is not read through */
     { ngx_string("vts_request_time"), NULL,
       ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_time),
+      offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_times),
       NGX_HTTP_VAR_NOCACHEABLE, 0 },
 
 #if (NGX_HTTP_CACHE)
@@ -152,9 +153,9 @@ ngx_http_vhost_traffic_status_node_variable(ngx_http_request_t *r,
 
     vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-    if (data == offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_time)) {
+    if (data == offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_times)) {
 
-        /* not kept up to date by the request path, average the queue here */
+        /* the queue is the value, there is no counter kept for it */
 
         value = (ngx_atomic_t) ngx_http_vhost_traffic_status_node_time_queue_average(
                                    &vtsn->stat_request_times, vtscf->average_method,

--- a/t/036.control_delete_expire.t
+++ b/t/036.control_delete_expire.t
@@ -318,7 +318,7 @@ __DATA__
     '"fresh":\{'
 ]
 
-=== TEST 11: ignore_status hides the activity from expire
+=== TEST 11: a zone serving an ignored status is still being used
 --- http_config
     vhost_traffic_status_zone;
 --- config
@@ -349,13 +349,6 @@ __DATA__
 [
     'nope',
     'filter:OK',
-    '"processingCounts":1',
-    '"normal":\{'
-]
---- response_body_unlike eval
-[
-    'nothing',
-    'nothing',
-    'nothing',
+    '"processingCounts":0',
     '"ignored":\{'
 ]

--- a/t/036.control_delete_expire.t
+++ b/t/036.control_delete_expire.t
@@ -1,0 +1,169 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket;
+
+# Two checks per request, and the blocks do not hold the same number of
+# them, so the total is spelled out rather than derived from blocks().
+plan tests => repeat_each() * 42;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: expire drops the node that has aged and keeps the recent one
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    # only here to spend time between the two nodes above; it carries no
+    # filter of its own
+    location /slow {
+        proxy_pass http://127.0.0.1:1981;
+    }
+--- request eval
+[
+    'GET /f?k=stale',
+    'GET /slow',
+    'GET /f?k=fresh',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=1",
+    'GET /status/format/json',
+]
+--- tcp_listen: 1981
+--- tcp_reply_delay: 2s
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nslow:OK\n"
+--- response_body_like eval
+[
+    'filter:OK',
+    'slow:OK',
+    'filter:OK',
+    '"processingCounts":1',
+    '"fresh"'
+]
+
+=== TEST 2: the node that aged is the one that went
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /slow {
+        proxy_pass http://127.0.0.1:1981;
+    }
+--- request eval
+[
+    'GET /f?k=stale',
+    'GET /slow',
+    'GET /f?k=fresh',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=1",
+    'GET /status/format/json',
+]
+--- tcp_listen: 1981
+--- tcp_reply_delay: 2s
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nslow:OK\n"
+--- response_body_unlike eval
+[
+    'nothing',
+    'nothing',
+    'nothing',
+    'nothing',
+    '"stale"'
+]
+
+=== TEST 3: an expire nothing has reached removes nothing
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=one',
+    'GET /f?k=two',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=3600",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    '"processingCounts":0',
+    '"one"'
+]
+
+=== TEST 4: without expire the whole group still goes
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=one',
+    'GET /f?k=two',
+    "GET /status/control?cmd=delete&group=filter&zone=*",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    '"processingCounts":2',
+    '"usedNode":1'
+]
+
+=== TEST 5: group=* with expire keeps what has not aged
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=one',
+    "GET /status/control?cmd=delete&group=*&zone=*&expire=3600",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    '"processingCounts":0',
+    '"one"'
+]

--- a/t/036.control_delete_expire.t
+++ b/t/036.control_delete_expire.t
@@ -83,7 +83,7 @@ __DATA__
     'nothing',
     'nothing',
     'nothing',
-    '"stale"'
+    '"stale":\{'
 ]
 
 === TEST 3: an expire nothing has reached removes nothing

--- a/t/036.control_delete_expire.t
+++ b/t/036.control_delete_expire.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket;
 
 # Two checks per request, and the blocks do not hold the same number of
 # them, so the total is spelled out rather than derived from blocks().
-plan tests => repeat_each() * 42;
+plan tests => repeat_each() * 78;
 no_shuffle();
 run_tests();
 
@@ -166,4 +166,154 @@ __DATA__
     'filter:OK',
     '"processingCounts":0',
     '"one"'
+]
+
+=== TEST 6: a named zone that has aged is deleted
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /slow {
+        proxy_pass http://127.0.0.1:1981;
+    }
+--- request eval
+[
+    'GET /f?k=stale',
+    'GET /slow',
+    "GET /status/control?cmd=delete&group=filter&zone=g::localhost\@stale&expire=1",
+    'GET /status/format/json',
+]
+--- tcp_listen: 1981
+--- tcp_reply_delay: 2s
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nslow:OK\n"
+--- response_body_unlike eval
+[
+    'nothing',
+    'nothing',
+    '"processingCounts":0',
+    '"stale":\{'
+]
+
+=== TEST 7: a named zone that has not aged is left alone
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=fresh',
+    "GET /status/control?cmd=delete&group=filter&zone=g::localhost\@fresh&expire=1h",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    '"processingCounts":0',
+    '"fresh":\{'
+]
+
+=== TEST 8: an expire that cannot be read leaves everything alone
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=one',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=typo",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    '"processingReturn":false',
+    '"one":\{'
+]
+
+=== TEST 9: a negative expire is refused the same way
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /f?k=one',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=-1",
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    '"processingReturn":false',
+    '"one":\{'
+]
+
+=== TEST 10: the suffix form is read the same as the seconds
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /slow {
+        proxy_pass http://127.0.0.1:1981;
+    }
+--- request eval
+[
+    'GET /f?k=stale',
+    'GET /slow',
+    'GET /f?k=fresh',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=1s",
+    'GET /status/format/json',
+]
+--- tcp_listen: 1981
+--- tcp_reply_delay: 2s
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nslow:OK\n"
+--- response_body_like eval
+[
+    'filter:OK',
+    'slow:OK',
+    'filter:OK',
+    '"processingCounts":1',
+    '"fresh":\{'
 ]

--- a/t/036.control_delete_expire.t
+++ b/t/036.control_delete_expire.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket;
 
 # Two checks per request, and the blocks do not hold the same number of
 # them, so the total is spelled out rather than derived from blocks().
-plan tests => repeat_each() * 78;
+plan tests => repeat_each() * 86;
 no_shuffle();
 run_tests();
 
@@ -316,4 +316,46 @@ __DATA__
     'filter:OK',
     '"processingCounts":1',
     '"fresh":\{'
+]
+
+=== TEST 11: ignore_status hides the activity from expire
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+    location /ig {
+        vhost_traffic_status_ignore_status 4xx;
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 404 "nope";
+    }
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+--- request eval
+[
+    'GET /ig?k=ignored',
+    'GET /f?k=normal',
+    "GET /status/control?cmd=delete&group=filter&zone=*&expire=1h",
+    'GET /status/format/json',
+]
+--- error_code eval
+[404, 200, 200, 200]
+--- response_body_like eval
+[
+    'nope',
+    'filter:OK',
+    '"processingCounts":1',
+    '"normal":\{'
+]
+--- response_body_unlike eval
+[
+    'nothing',
+    'nothing',
+    'nothing',
+    '"ignored":\{'
 ]


### PR DESCRIPTION
Addresses the part of #136 that the issue actually asks for — "a time setting
to mark an upstream as stale and evict memory for its stored metrics". The
design, and the measurements behind choosing this shape over the alternatives,
are in
https://github.com/vozlt/nginx-module-vts/issues/136#issuecomment-5230277228.

```
/status/control?cmd=delete&group=*&zone=*&expire=3600
```

Delete the nodes that `group` and `zone` already select whose last request is
older than the given number of seconds. Without `expire` nothing changes.
`processingCounts` reports how many went.

## Why an argument and not a directive

A sweep on insertion would put a walk of the tree back on the hot path, and it
cannot run at all once insertions are being refused — which is the state it is
most needed in. The control interface still works on an exhausted zone:

```
usedNode=244 freeSize=0
new key    -> usedNode=244   (refused)
delete     -> processingCounts=243, freeSize=983040
new key    -> usedNode=2     (recovered)
```

If automatic sweeping is wanted later it can call the same predicate.

## What the change touches

`node_expire_match()` holds the predicate and three places consult it: the walk
that collects a group, the single-zone lookup, and `group=*`. That last one had
to change path — `delete_all()` empties the tree by taking its root until there
is none, which cannot leave anything behind, so with an `expire` the collecting
walk is used instead, taking every type.

The age is `stat_request_times.times[rear]`. Every type carries it, cache nodes
included; they simply do not show it in the JSON, which I confirmed by reading a
dump rather than trusting the output:

```
'CC\x1fc1'     times[rear]=1786257149271  age=3060 ms
'NO\x1ffront'  times[rear]=1786257149282  age=3049 ms
```

A node records a time when it is **created**, not only when it is found again
(`node_init()` ends in `node_update()`), so a node made a moment ago is not
mistaken for a stale one. Nothing is added to the node, so the dump format is
untouched.

The difference is taken in `ngx_msec_t`. The stored value is the epoch in
milliseconds and `ngx_msec_t` is as wide as a pointer, so a 32 bit build wraps
every 49.7 days; subtracting in the same unsigned type stays right across the
wrap, and that is what limits a usable `expire`.

An `expire` that does not parse leaves the command undone. `expire=typo`
silently deleting the whole selection is the more expensive way to be wrong.

## Checks

The first commit is the test alone, and CI on it was red in exactly the two
jobs that run the suite — `build` and `asan` — with the three that only compile
passing. The implementation turns both green.

The rest of the suite is unchanged: run file by file, with and without the
change, `PASS=24 FAIL=12` both times and **the same twelve files** (they want
an nginx on port 80). Builds clean with and without `--without-http_cache`.

The second commit fixes a fault in the test itself: it asserted that `"stale"`
was absent after the sweep, but every zone carries a `"stale"` counter among
its cache statuses, so the pattern matched whatever the code did. The filter key
holds an object and the counter holds a number, so it now anchors on the brace.
