### PR TITLE
ci: pin promtool instead of asking for the latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,19 @@ jobs:
           sudo apt install -y cpanminus
           sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
       - name: 'prepare promtool'
+        env:
+          # pinned, like the nginx checkout and the actions above it. Asking
+          # the api for the latest release is an unauthenticated call from a
+          # shared runner address, and when it is rate limited the command
+          # substitution yields nothing, so curl is handed no url at all and
+          # the step fails somewhere unrelated to what it was testing
+          PROMETHEUS_VERSION: '3.13.2'
         run: |
-          sudo apt-get update && sudo apt-get install -y curl
-          curl -L $(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4) -o prometheus-latest.tar.gz
-          tar xvf prometheus-latest.tar.gz
+          curl -fsSL -o prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar xzf prometheus.tar.gz
           sudo mv prometheus-*/promtool /usr/local/bin
+          promtool --version
       - name: 'test'
         working-directory: nginx-module-vts
         run: |
@@ -140,11 +148,19 @@ jobs:
           sudo apt install -y cpanminus
           sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
       - name: 'prepare promtool'
+        env:
+          # pinned, like the nginx checkout and the actions above it. Asking
+          # the api for the latest release is an unauthenticated call from a
+          # shared runner address, and when it is rate limited the command
+          # substitution yields nothing, so curl is handed no url at all and
+          # the step fails somewhere unrelated to what it was testing
+          PROMETHEUS_VERSION: '3.13.2'
         run: |
-          sudo apt-get update && sudo apt-get install -y curl
-          curl -L $(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4) -o prometheus-latest.tar.gz
-          tar xvf prometheus-latest.tar.gz
+          curl -fsSL -o prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar xzf prometheus.tar.gz
           sudo mv prometheus-*/promtool /usr/local/bin
+          promtool --version
       - name: 'relax ASLR entropy'
         # the sanitizer runtime cannot map its shadow memory with the high
         # entropy ASLR of the ubuntu-24.04 kernel


### PR DESCRIPTION
The `prepare promtool` step asked the API for the latest prometheus release
and fed the answer straight to curl:

```
curl -L $(curl -s https://api.github.com/repos/prometheus/prometheus/releases/latest | ...) -o prometheus-latest.tar.gz
```

That inner call is unauthenticated and goes out from a shared runner address,
so it gets rate limited from time to time. When it does, the command
substitution yields nothing, curl is handed no url at all, and the step dies:

```
curl: (2) no URL specified
curl: try 'curl --help' or 'curl --manual' for more information
##[error]Process completed with exit code 2.
```

That is what took the asan job down on #375 — a change to a test file and a
README, nothing to do with prometheus. The failure lands on a step named after
a tool the run had not reached yet, so it reads as though the change under
test broke something. Re-running the job with no other change turned it green.

## The change

Pin the version, the way the nginx checkout and every action in this file are
already pinned. Both jobs carry the step, so both move.

`curl` gets `-f`, so a bad download fails at this step rather than as a
confusing `tar` error afterwards, and `promtool --version` proves the binary
runs before any test depends on it.

The `apt-get install -y curl` goes with it: ubuntu-24.04 runners already carry
curl, and every log said so — `curl is already the newest version`.

## Checked

The pinned URL resolves and carries what it should:

```
HTTP 200, 104531850 bytes, contains promtool
```

The workflow still parses, and both jobs get the version.
