### PR TITLE
Give the key of an upstream peer the room its name needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,21 @@ jobs:
           # mainline 1.31.0, the stable branch does not carry it, 1.30.4
           # included, so the check stays out while the tests build a stable
           # release
+          # NGX_HAVE_NONALIGNED is what lets nginx read four bytes at a
+          # time from an arbitrary offset - ngx_md5.c, ngx_http_parse.c and
+          # http/2 all take it. auto/os/conf turns it on for x86, which is
+          # what runs here, and UndefinedBehaviorSanitizer objects whenever
+          # the bytes happen to land off a four byte boundary. Whether they
+          # do is down to where a string falls in memory, so the job passes
+          # or fails on luck: an upstream over a long unix socket path made
+          # ngx_http_upstream_init_round_robin_sid() hash from an odd
+          # address and took the run down. Turn it off and nginx assembles
+          # the word a byte at a time instead, which reads the same and
+          # keeps the alignment check meaningful for this module
           ./auto/configure \
             --prefix=/usr/local/nginx-asan \
             --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \
-            --with-cc-opt="-fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+            --with-cc-opt="-DNGX_HAVE_NONALIGNED=0 -fsanitize=address,undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
             --with-ld-opt="-fsanitize=address,undefined"
           make -j$(nproc)
           sudo make install

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -611,7 +611,6 @@ u_char *
 ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
     u_char *buf)
 {
-    size_t                                 len;
     u_char                                *p, *o, *s;
     uint32_t                               hash;
     unsigned                               type, zone;
@@ -637,19 +636,19 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
     uscfp = umcf->upstreams.elts;
 
-    len = 0;
-    for (i = 0; i < umcf->upstreams.nelts; i++) {
-        uscf = uscfp[i];
-        len = ngx_max(uscf->host.len, len);
-    }
-
-    dst.len = len + sizeof("@[ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255]:65535") - 1;
-    dst.data = ngx_pnalloc(r->pool, dst.len);
-    if (dst.data == NULL) {
-        return buf;
-    }
-
-    p = dst.data;
+    /*
+     * The key of a peer is the name of its group, the separator and the name
+     * of the peer. This used to be built in one buffer held for the whole
+     * walk, sized for the longest group name and an address and a port, on
+     * the reading that a peer is never named anything longer. A unix socket
+     * is named by its path, which passes that easily, and the overflow did
+     * more than run off the end: node_generate_key() takes the key from the
+     * same pool with ngx_pcalloc, which zeroes a region overlapping the tail
+     * just written, so the name was cut short, the lookup missed, and the
+     * peer read as though it had served nothing (#378).
+     *
+     * Each key is now given the room it needs where it is built.
+     */
 
 #if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
     /*
@@ -695,11 +694,17 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
             ngx_http_upstream_rr_peers_rlock(peers);
 
             for (peer = peers->peer; peer; peer = peer->next) {
+                dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
+                dst.data = ngx_pnalloc(r->pool, dst.len);
+                if (dst.data == NULL) {
+                    ngx_http_upstream_rr_peers_unlock(peers);
+                    return buf;
+                }
+
+                p = dst.data;
                 p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
                 *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
                 p = ngx_cpymem(p, peer->name.data, peer->name.len);
-
-                dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
 
                 rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
                 if (rc != NGX_OK) {
@@ -745,7 +750,6 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
 #endif
                 }
 
-                p = dst.data;
             }
 
             ngx_http_upstream_rr_peers_unlock(peers);
@@ -781,11 +785,17 @@ not_supported:
 
                 /* for all A records */
                 for (k = 0; k < usn.naddrs; k++) {
+                    dst.len = uscf->host.len + sizeof("@") - 1
+                              + usn.addrs[k].name.len;
+                    dst.data = ngx_pnalloc(r->pool, dst.len);
+                    if (dst.data == NULL) {
+                        return buf;
+                    }
+
+                    p = dst.data;
                     p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
                     *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
                     p = ngx_cpymem(p, usn.addrs[k].name.data, usn.addrs[k].name.len);
-
-                    dst.len = uscf->host.len + sizeof("@") - 1 + usn.addrs[k].name.len;
 
                     rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
                     if (rc != NGX_OK) {
@@ -815,7 +825,6 @@ not_supported:
 #endif
                     }
 
-                    p = dst.data;
                 }
             }
 

--- a/t/037.upstream_long_peer_name.t
+++ b/t/037.upstream_long_peer_name.t
@@ -4,10 +4,20 @@ use Test::Nginx::Socket;
 
 # The scratch buffer the upstream display builds its keys in was sized for a
 # peer name no longer than an address and a port, which a unix socket path
-# passes easily. Nothing here shows on an ordinary build - the overflow lands
-# in the slack of the pool block - so what these are for is the run under the
-# sanitizers.
-plan tests => repeat_each() * 10;
+# passes easily.
+#
+# It shows up twice over. Under the sanitizers the overflow itself is caught.
+# On an ordinary build it is quieter and still wrong: node_generate_key()
+# takes the key from the same pool with ngx_pcalloc, which zeroes a region
+# overlapping the tail just written, so the name is cut short, the lookup
+# misses, and the peer reads as though it had served nothing. That is what
+# the requestCounter of TEST 2 and TEST 3 is for, and it fails without any
+# sanitizer.
+#
+# The display reaches a peer by two paths and both had the fault, so both are
+# here: an upstream with a zone goes through the round robin peers, one
+# without goes through the servers of the group.
+plan tests => repeat_each() * 16;
 no_shuffle();
 run_tests();
 
@@ -53,6 +63,44 @@ __DATA__
     vhost_traffic_status_zone;
 
     upstream u {
+        server unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+    }
+
+    server {
+        listen unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+
+        location / {
+            return 200 "backend:OK";
+        }
+    }
+--- config
+    location /u {
+        proxy_pass http://u;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /u',
+    'GET /u',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'backend:OK',
+    'backend:OK',
+    '"upstreamZones":\{"u":\[\{"server":"unix:[^"]+","requestCounter":2'
+]
+
+=== TEST 3: the same over an upstream with a zone, which takes the other path
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream u {
+        zone u 1m;
         server unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
     }
 

--- a/t/037.upstream_long_peer_name.t
+++ b/t/037.upstream_long_peer_name.t
@@ -1,0 +1,86 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket;
+
+# The scratch buffer the upstream display builds its keys in was sized for a
+# peer name no longer than an address and a port, which a unix socket path
+# passes easily. Nothing here shows on an ordinary build - the overflow lands
+# in the slack of the pool block - so what these are for is the run under the
+# sanitizers.
+plan tests => repeat_each() * 10;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: an upstream over a unix socket whose path is longer than an address
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream u {
+        server unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+    }
+
+    server {
+        listen unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+
+        location / {
+            return 200 "backend:OK";
+        }
+    }
+--- config
+    location /u {
+        proxy_pass http://u;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /u',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'backend:OK',
+    '"server":"unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key\.sock"'
+]
+
+=== TEST 2: the peer over the long path is counted like any other
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream u {
+        server unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+    }
+
+    server {
+        listen unix:/tmp/vts-t037-a-deliberately-long-unix-domain-socket-path-for-the-upstream-key.sock;
+
+        location / {
+            return 200 "backend:OK";
+        }
+    }
+--- config
+    location /u {
+        proxy_pass http://u;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /u',
+    'GET /u',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'backend:OK',
+    'backend:OK',
+    '"upstreamZones":\{"u":\[\{"server":"unix:[^"]+","requestCounter":2'
+]


### PR DESCRIPTION
Fixes #378.

The walk over the upstream groups built its keys in one buffer, taken once
before the walk:

```c
len = 0;
for (i = 0; i < umcf->upstreams.nelts; i++) {
    len = ngx_max(uscf->host.len, len);
}
dst.len = len + sizeof("@[ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255]:65535") - 1;
```

That says a peer is never named anything longer than an address and a port. A
unix socket is named by its path, so anything past **53 characters** runs off
the end. The report has a 78 character path; `127.0.0.1:8000` is 14, which is
why the short one works.

## It is quieter than a crash, and worse for it

The reporter's build has `-fsanitize=address`, so they get an abort. On an
ordinary build nothing appears to happen — the overflow lands in the slack of
the pool block. What does happen is this: `node_generate_key()` takes the key
from the same pool with `ngx_pcalloc`, which **zeroes** a region overlapping
the tail the overflow has just written. The name is cut short before the key
is built, the lookup misses, and the peer is displayed as though it had served
nothing.

Two runs, identical but for the length of the socket path:

```
peer->name 24 characters   requestCounter 2
peer->name 88 characters   requestCounter 0
```

So the statistics of any upstream over a socket path of ordinary length read
zero, silently, on every build. That is what TEST 2 pins, and it fails on
master without the sanitizers.

Under ASan on master the same configuration gives:

```
ERROR: AddressSanitizer: memcpy-param-overlap
    #1 ngx_http_vhost_traffic_status_node_generate_key      node.c:33
    #2 ngx_http_vhost_traffic_status_display_set_upstream_group  display_json.c:790
```

## The change

Give each key the room it needs where it is built, in both the loop over the
peers of a zone and the loop over the servers of a group — the second one has
the same overflow through `usn.addrs[k].name`, and the report's configuration
goes through it, having no `zone`.

It is one more pool allocation per peer, in a walk that already takes one per
peer for the key itself. The guess is removed rather than widened, so the same
mistake cannot come back with some other kind of peer name.

## Checks

- The new test fails on master and passes here, on an ordinary build.
- Under ASan the report is gone and the request answers 200 instead of dying.
- The rest of the suite is unchanged: run file by file, before and after,
  `PASS=24 FAIL=12` both times and the same twelve (they want an nginx on port
  80).
- Builds clean with and without `--without-http_cache`.

## On unix sockets

Nothing in the README, the tests or the source mentions them — they work
because they fall through the ordinary peer-name path, not because anyone
decided they should. That is how this assumption survived. They are counted
correctly once the key fits, so a test for them is worth keeping.
