### PR TITLE
Let the control interface find the peers an upstream resolved at run time

### DIFF
--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -138,7 +138,18 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
                         }
 
 #if nginx_version > 1007001
-                        usn->name = peer->name;
+
+                        /*
+                         * ush rather than peer->name: the name of a peer
+                         * lives in the zone of the upstream and a re-resolve
+                         * can hand it back to the slab as soon as the lock
+                         * below is released, while the caller reads this
+                         * afterwards to write its answer. The two were just
+                         * compared byte for byte, and ush belongs to the
+                         * request.
+                         */
+
+                        usn->name = ush;
 #endif
 
                         usn->weight = peer->weight;
@@ -150,8 +161,9 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
                         usn->down = ngx_http_upstream_check_peer_down(
                                         peer->check_index) ? 1 : 0;
 #else
-                        usn->down = (peer->fails >= peer->max_fails
-                                     || peer->down);
+                        usn->down = (peer->down
+                                     || (peer->max_fails
+                                         && peer->fails >= peer->max_fails));
 #endif
 
                         control->count++;

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -9,6 +9,10 @@
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
 
+#if (NGX_HTTP_UPSTREAM_CHECK)
+#include "ngx_http_upstream_check_module.h"
+#endif
+
 
 static void ngx_http_vhost_traffic_status_node_status_all(
     ngx_http_vhost_traffic_status_control_t *control);
@@ -46,6 +50,10 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
     ngx_str_t                       key, usg, ush;
     ngx_uint_t                      i, j, k;
     ngx_http_upstream_server_t     *us;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_http_upstream_rr_peer_t    *peer;
+    ngx_http_upstream_rr_peers_t   *peers;
+#endif
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
 
@@ -97,6 +105,68 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
 
         if (uscf->host.len == usg.len) {
             if (ngx_strncmp(uscf->host.data, usg.data, usg.len) == 0) {
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+
+                /*
+                 * A server line that resolves its name at run time leaves
+                 * nothing to match on: ngx_http_upstream_server() keeps a
+                 * placeholder holding the port, and addrs[0].name is never
+                 * set. The peers are made by the resolver and live in the
+                 * zone, which is where the display reads them since #322.
+                 *
+                 * Look there first, and fall back to the server lines, which
+                 * still carry the backup peers - the display splits them the
+                 * same way.
+                 */
+
+                if (uscf->shm_zone != NULL) {
+                    peers = uscf->peer.data;
+
+                    ngx_http_upstream_rr_peers_rlock(peers);
+
+                    for (peer = peers->peer; peer; peer = peer->next) {
+
+                        if (peer->name.len != ush.len) {
+                            continue;
+                        }
+
+                        if (ngx_strncmp(peer->name.data, ush.data, ush.len)
+                            != 0)
+                        {
+                            continue;
+                        }
+
+#if nginx_version > 1007001
+                        usn->name = peer->name;
+#endif
+
+                        usn->weight = peer->weight;
+                        usn->max_fails = peer->max_fails;
+                        usn->fail_timeout = peer->fail_timeout;
+                        usn->backup = 0;
+
+#if (NGX_HTTP_UPSTREAM_CHECK)
+                        usn->down = ngx_http_upstream_check_peer_down(
+                                        peer->check_index) ? 1 : 0;
+#else
+                        usn->down = (peer->fails >= peer->max_fails
+                                     || peer->down);
+#endif
+
+                        control->count++;
+
+                        break;
+                    }
+
+                    ngx_http_upstream_rr_peers_unlock(peers);
+                }
+
+                if (control->count) {
+                    break;
+                }
+
+#endif
 
                 for (j = 0; j < uscf->servers->nelts; j++) {
 

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -727,7 +727,15 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
                     usn.down = 0;
                 }
 #else
-                usn.down = (peer->fails >= peer->max_fails || peer->down);
+                /*
+                 * max_fails 0 turns the counting off, which nginx reads as
+                 * never taking the peer out; without the guard the comparison
+                 * holds from the first request and every such peer is called
+                 * down
+                 */
+                usn.down = (peer->down
+                            || (peer->max_fails
+                                && peer->fails >= peer->max_fails));
 #endif
 
 #if nginx_version > 1007001

--- a/t/038.control_resolve_peers.t
+++ b/t/038.control_resolve_peers.t
@@ -1,0 +1,184 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The `resolve` parameter of the upstream server directive needs nginx 1.27.3
+# or later, freenginx does not have it.
+#
+# #322 gave the display a path that reads the peers an upstream group made at
+# run time. The control interface never got one, so it looks for the peer in
+# the addrs[] of the server line, which a `resolve` line leaves empty. The
+# statistics are in the tree and the display shows them; the control interface
+# answers with nothing.
+#
+# The two blocks below reach the same lookup from its two call sites, which
+# differ in whether the mutex of the zone is held: the control handler holds
+# it, vhost_traffic_status_set_by_filter does not.
+
+use Test::Nginx::Socket;
+use Socket;
+use POSIX ();
+
+my $nginx = $ENV{TEST_NGINX_BINARY} || 'nginx';
+my $version = `$nginx -v 2>&1` || '';
+my $supported = 0;
+
+if ($version =~ m{^nginx version: nginx/(\d+)\.(\d+)\.(\d+)}) {
+    $supported = ($1 * 1000000 + $2 * 1000 + $3) >= 1027003;
+}
+
+plan skip_all => "upstream resolve is not supported by: $version"
+    unless $supported;
+
+# the test resolver
+
+my $DNSPort    = 18654;
+my $FirstAddr  = '127.0.0.1';   # port 1984 of the test server answers here
+my $SecondAddr = '127.0.0.1';   # the name keeps one address for these tests
+my $SwitchIn   = 3600;
+
+# Sends a query and tells whether the test resolver answers it.
+sub dns_ready {
+    my $sock;
+
+    socket($sock, PF_INET, SOCK_DGRAM, getprotobyname('udp')) or return 0;
+
+    my $to = sockaddr_in($DNSPort, inet_aton('127.0.0.1'));
+    my $query = pack('n n n n n n', 0x2a2a, 0x0100, 1, 0, 0, 0)
+                . join('', map { chr(length $_) . $_ } qw(vts-test example))
+                . "\0" . pack('n n', 1, 1);
+
+    for (1 .. 30) {
+        next unless send($sock, $query, 0, $to);
+
+        my $rin = '';
+        vec($rin, fileno($sock), 1) = 1;
+
+        if (select($rin, undef, undef, 0.1)) {
+            my $answer;
+            recv($sock, $answer, 512, 0);
+            close $sock;
+            return 1;
+        }
+    }
+
+    close $sock;
+
+    return 0;
+}
+
+# The resolver runs as its own process: a plain fork of the test is not safe
+# on every platform.
+my $dns_pid = fork();
+
+defined $dns_pid or plan skip_all => "fork() failed: $!";
+
+if ($dns_pid == 0) {
+    my $server = __FILE__;
+    $server =~ s{[^/]+$}{dns_server.pl};
+
+    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
+        or POSIX::_exit(1);
+}
+
+END {
+    if ($dns_pid) {
+        local $?;
+
+        kill 'TERM', $dns_pid;
+        waitpid($dns_pid, 0);
+    }
+}
+
+plan skip_all => "the test resolver does not answer on 127.0.0.1:$DNSPort"
+    unless dns_ready();
+
+plan tests => repeat_each() * 15;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: the control interface finds a peer the resolver made
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18654 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server vts-test.example:1984 resolve;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /status/format/json',
+    "GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1984",
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"upstreamZones".*"127\.0\.0\.1:1984"/s,
+    qr/"server":"127\.0\.0\.1:1984".*"requestCounter":1/s,
+]
+
+=== TEST 2: set_by_filter reaches the same peer, with no mutex held
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18654 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server vts-test.example:1984 resolve;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /peer {
+        vhost_traffic_status_set_by_filter $counter upstream@group/backend@127.0.0.1:1984/requestCounter;
+        add_header X-Peer-Counter $counter;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- user_files eval
+[
+    ['peer/file.txt' => 'peer:OK']
+]
+--- request eval
+[
+    'GET /up',
+    'GET /peer/file.txt',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'OK',
+    'peer:OK',
+    qr/"upstreamZones".*"127\.0\.0\.1:1984"/s,
+]
+--- raw_response_headers_like eval
+[
+    '',
+    qr/X-Peer-Counter: [1-9]/,
+    '',
+]

--- a/t/038.control_resolve_peers.t
+++ b/t/038.control_resolve_peers.t
@@ -91,7 +91,7 @@ END {
 plan skip_all => "the test resolver does not answer on 127.0.0.1:$DNSPort"
     unless dns_ready();
 
-plan tests => repeat_each() * 15;
+plan tests => repeat_each() * 21;
 no_shuffle();
 run_tests();
 
@@ -181,4 +181,40 @@ __DATA__
     '',
     qr/X-Peer-Counter: [1-9]/,
     '',
+]
+
+=== TEST 3: max_fails=0 turns the counting off, it does not mean down
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18654 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server vts-test.example:1984 resolve max_fails=0;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /status/format/json',
+    "GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1984",
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"127\.0\.0\.1:1984".*"down":false/s,
+    qr/"server":"127\.0\.0\.1:1984".*"down":false/s,
 ]


### PR DESCRIPTION
Closes #357.

The display of an upstream group whose names are resolved at run time lists
its peers; the control interface finds none of them.

**This first commit is the test only, so the run against it should be red.**
The implementation follows.
