### PR TITLE
Keep the count the filter cap needs rather than walking the tree for it

### DIFF
--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -580,11 +580,7 @@ ngx_http_vhost_traffic_status_node_delete_all(
     while (node != sentinel) {
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-        if (ngx_http_vhost_traffic_status_node_filter_counted(control->r, vtsn)
-            == NGX_OK)
-        {
-            ctx->shm->filter_nodes--;
-        }
+        ngx_http_vhost_traffic_status_node_filter_account(ctx, vtsn, -1);
 
         ngx_rbtree_delete(ctx->rbtree, node);
         ngx_slab_free_locked(shpool, node);
@@ -640,11 +636,7 @@ ngx_http_vhost_traffic_status_node_delete_group(
 
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-        if (ngx_http_vhost_traffic_status_node_filter_counted(control->r, vtsn)
-            == NGX_OK)
-        {
-            ctx->shm->filter_nodes--;
-        }
+        ngx_http_vhost_traffic_status_node_filter_account(ctx, vtsn, -1);
 
         ngx_rbtree_delete(ctx->rbtree, node);
         ngx_slab_free_locked(shpool, node);
@@ -688,12 +680,7 @@ ngx_http_vhost_traffic_status_node_delete_zone(
         if (ngx_http_vhost_traffic_status_node_expire_match(control, vtsn)
             == NGX_OK)
         {
-            if (ngx_http_vhost_traffic_status_node_filter_counted(control->r,
-                                                                 vtsn)
-                == NGX_OK)
-            {
-                ctx->shm->filter_nodes--;
-            }
+            ngx_http_vhost_traffic_status_node_filter_account(ctx, vtsn, -1);
 
             ngx_rbtree_delete(ctx->rbtree, node);
             ngx_slab_free_locked(shpool, node);

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -566,6 +566,7 @@ ngx_http_vhost_traffic_status_node_delete_all(
     ngx_slab_pool_t                           *shpool;
     ngx_rbtree_node_t                         *node, *sentinel;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     ctx = ngx_http_get_module_main_conf(control->r, ngx_http_vhost_traffic_status_module);
@@ -577,6 +578,13 @@ ngx_http_vhost_traffic_status_node_delete_all(
     shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
 
     while (node != sentinel) {
+        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+
+        if (ngx_http_vhost_traffic_status_node_filter_counted(control->r, vtsn)
+            == NGX_OK)
+        {
+            ctx->shm->filter_nodes--;
+        }
 
         ngx_rbtree_delete(ctx->rbtree, node);
         ngx_slab_free_locked(shpool, node);
@@ -598,6 +606,7 @@ ngx_http_vhost_traffic_status_node_delete_group(
     ngx_slab_pool_t                           *shpool;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_delete_t    *deletes;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
@@ -628,6 +637,14 @@ ngx_http_vhost_traffic_status_node_delete_group(
 
     for (i = 0; i < n; i++) {
         node = deletes[i].node;
+
+        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+
+        if (ngx_http_vhost_traffic_status_node_filter_counted(control->r, vtsn)
+            == NGX_OK)
+        {
+            ctx->shm->filter_nodes--;
+        }
 
         ngx_rbtree_delete(ctx->rbtree, node);
         ngx_slab_free_locked(shpool, node);
@@ -671,6 +688,13 @@ ngx_http_vhost_traffic_status_node_delete_zone(
         if (ngx_http_vhost_traffic_status_node_expire_match(control, vtsn)
             == NGX_OK)
         {
+            if (ngx_http_vhost_traffic_status_node_filter_counted(control->r,
+                                                                 vtsn)
+                == NGX_OK)
+            {
+                ctx->shm->filter_nodes--;
+            }
+
             ngx_rbtree_delete(ctx->rbtree, node);
             ngx_slab_free_locked(shpool, node);
 

--- a/src/ngx_http_vhost_traffic_status_dump.c
+++ b/src/ngx_http_vhost_traffic_status_dump.c
@@ -324,6 +324,10 @@ ngx_http_vhost_traffic_status_dump_restore_add_node(ngx_event_t *ev,
         ngx_memcpy(vtsn->data, key->data, key->len);
 
         ngx_rbtree_insert(ctx->rbtree, node);
+
+        /* a node put back from the file counts like any other */
+
+        ngx_http_vhost_traffic_status_node_filter_account(ctx, vtsn, 1);
     }
 
     ngx_shmtx_unlock(&shpool->mutex);

--- a/src/ngx_http_vhost_traffic_status_filter.c
+++ b/src/ngx_http_vhost_traffic_status_filter.c
@@ -281,24 +281,41 @@ ngx_http_vhost_traffic_status_filter_max_node_signature(
     ngx_uint_t                                     i, n;
     ngx_http_vhost_traffic_status_filter_match_t  *matches;
 
-    /* not the crc of nothing: a cap of zero has to differ from a cap of one */
+    /*
+     * Framed rather than combined: the earlier version folded each group in
+     * with xor, which lets a group named twice cancel itself out, so
+     * "3 g:: g::" signed the same as "3" - and those match different things,
+     * the second one matching every filter there is. Each length goes in
+     * before its bytes so that the same bytes split differently do not sign
+     * alike either.
+     */
 
-    signature = ngx_crc32_long((u_char *) &ctx->filter_max_node,
-                               sizeof(ngx_uint_t));
+    ngx_crc32_init(signature);
 
-    if (ctx->filter_max_node_matches == NULL) {
-        return signature;
+    ngx_crc32_update(&signature, (u_char *) &ctx->filter_max_node,
+                     sizeof(ngx_uint_t));
+
+    n = ctx->filter_max_node_matches == NULL
+        ? 0 : ctx->filter_max_node_matches->nelts;
+
+    ngx_crc32_update(&signature, (u_char *) &n, sizeof(ngx_uint_t));
+
+    if (n) {
+        matches = ctx->filter_max_node_matches->elts;
+
+        for (i = 0; i < n; i++) {
+            ngx_crc32_update(&signature, (u_char *) &matches[i].match.len,
+                             sizeof(size_t));
+            ngx_crc32_update(&signature, matches[i].match.data,
+                             matches[i].match.len);
+        }
     }
 
-    matches = ctx->filter_max_node_matches->elts;
-    n = ctx->filter_max_node_matches->nelts;
+    ngx_crc32_final(signature);
 
-    for (i = 0; i < n; i++) {
-        signature = ngx_crc32_long(matches[i].match.data,
-                                   matches[i].match.len) ^ signature;
-    }
+    /* zero is kept for a count nobody has vouched for */
 
-    return signature;
+    return signature == 0 ? 1 : signature;
 }
 
 
@@ -306,11 +323,21 @@ ngx_int_t
 ngx_http_vhost_traffic_status_filter_max_node_match(ngx_http_request_t *r,
     ngx_str_t *filter)
 {
-    ngx_uint_t                                     i, n;
-    ngx_http_vhost_traffic_status_ctx_t           *ctx;
-    ngx_http_vhost_traffic_status_filter_match_t  *matches;
+    return ngx_http_vhost_traffic_status_filter_max_node_match_ctx(
+               ngx_http_get_module_main_conf(r,
+                   ngx_http_vhost_traffic_status_module),
+               filter);
+}
 
-    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+
+/* the dump restores nodes with no request in hand, so this takes the ctx */
+
+ngx_int_t
+ngx_http_vhost_traffic_status_filter_max_node_match_ctx(
+    ngx_http_vhost_traffic_status_ctx_t *ctx, ngx_str_t *filter)
+{
+    ngx_uint_t                                     i, n;
+    ngx_http_vhost_traffic_status_filter_match_t  *matches;
 
     if (ctx->filter_max_node_matches == NULL) {
         return NGX_OK;

--- a/src/ngx_http_vhost_traffic_status_filter.c
+++ b/src/ngx_http_vhost_traffic_status_filter.c
@@ -266,6 +266,42 @@ next:
 }
 
 
+/*
+ * What the cap counts is settled by its own value and by the groups it names,
+ * and both come from the configuration. A reload can change either while the
+ * zone carries a count made under the old ones, so the count is stamped with
+ * this and made again when they do not agree.
+ */
+
+uint32_t
+ngx_http_vhost_traffic_status_filter_max_node_signature(
+    ngx_http_vhost_traffic_status_ctx_t *ctx)
+{
+    uint32_t                                       signature;
+    ngx_uint_t                                     i, n;
+    ngx_http_vhost_traffic_status_filter_match_t  *matches;
+
+    /* not the crc of nothing: a cap of zero has to differ from a cap of one */
+
+    signature = ngx_crc32_long((u_char *) &ctx->filter_max_node,
+                               sizeof(ngx_uint_t));
+
+    if (ctx->filter_max_node_matches == NULL) {
+        return signature;
+    }
+
+    matches = ctx->filter_max_node_matches->elts;
+    n = ctx->filter_max_node_matches->nelts;
+
+    for (i = 0; i < n; i++) {
+        signature = ngx_crc32_long(matches[i].match.data,
+                                   matches[i].match.len) ^ signature;
+    }
+
+    return signature;
+}
+
+
 ngx_int_t
 ngx_http_vhost_traffic_status_filter_max_node_match(ngx_http_request_t *r,
     ngx_str_t *filter)

--- a/src/ngx_http_vhost_traffic_status_filter.h
+++ b/src/ngx_http_vhost_traffic_status_filter.h
@@ -47,8 +47,6 @@ ngx_int_t ngx_http_vhost_traffic_status_filter_get_keys(
 ngx_int_t ngx_http_vhost_traffic_status_filter_get_nodes(
     ngx_http_request_t *r, ngx_array_t **filter_nodes,
     ngx_str_t *name, ngx_rbtree_node_t *node);
-uint32_t ngx_http_vhost_traffic_status_filter_max_node_signature(
-    ngx_http_vhost_traffic_status_ctx_t *ctx);
 ngx_int_t ngx_http_vhost_traffic_status_filter_max_node_match(
     ngx_http_request_t *r, ngx_str_t *filter);
 

--- a/src/ngx_http_vhost_traffic_status_filter.h
+++ b/src/ngx_http_vhost_traffic_status_filter.h
@@ -47,6 +47,8 @@ ngx_int_t ngx_http_vhost_traffic_status_filter_get_keys(
 ngx_int_t ngx_http_vhost_traffic_status_filter_get_nodes(
     ngx_http_request_t *r, ngx_array_t **filter_nodes,
     ngx_str_t *name, ngx_rbtree_node_t *node);
+uint32_t ngx_http_vhost_traffic_status_filter_max_node_signature(
+    ngx_http_vhost_traffic_status_ctx_t *ctx);
 ngx_int_t ngx_http_vhost_traffic_status_filter_max_node_match(
     ngx_http_request_t *r, ngx_str_t *filter);
 

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -458,8 +458,19 @@ ngx_http_vhost_traffic_status_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 
     if (shm_zone->shm.exists) {
-        ctx->shm = shpool->data;
-        ctx->rbtree = &ctx->shm->rbtree;
+
+        /*
+         * A segment that outlived the binary that made it, which only
+         * happens on win32. shpool->data may have been allocated by a build
+         * that put nothing after the tree, so the room for the count is not
+         * there to use - reading it would be past the end of that
+         * allocation, and writing it would be past the end of what the slab
+         * handed out. Take the tree and leave the count alone; find_lru()
+         * counts by walking when there is nowhere to keep it.
+         */
+
+        ctx->rbtree = shpool->data;
+        ctx->shm = NULL;
         return NGX_OK;
     }
 

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -451,22 +451,35 @@ ngx_http_vhost_traffic_status_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     if (octx) {
         ctx->rbtree = octx->rbtree;
+        ctx->shm = octx->shm;
         return NGX_OK;
     }
 
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 
     if (shm_zone->shm.exists) {
-        ctx->rbtree = shpool->data;
+        ctx->shm = shpool->data;
+        ctx->rbtree = &ctx->shm->rbtree;
         return NGX_OK;
     }
 
-    ctx->rbtree = ngx_slab_alloc(shpool, sizeof(ngx_rbtree_t));
-    if (ctx->rbtree == NULL) {
+    /*
+     * The tree is the first member, so shpool->data goes on pointing at it.
+     * Nothing here touches what the zone already holds: on a reload this runs
+     * in the master while the old workers are still serving from it.
+     */
+
+    ctx->shm = ngx_slab_alloc(shpool, sizeof(ngx_http_vhost_traffic_status_shm_t));
+    if (ctx->shm == NULL) {
         return NGX_ERROR;
     }
 
-    shpool->data = ctx->rbtree;
+    ctx->shm->filter_nodes = 0;
+    ctx->shm->signature = 0;
+
+    ctx->rbtree = &ctx->shm->rbtree;
+
+    shpool->data = ctx->shm;
 
     sentinel = ngx_slab_alloc(shpool, sizeof(ngx_rbtree_node_t));
     if (sentinel == NULL) {
@@ -944,6 +957,8 @@ ngx_http_vhost_traffic_status_init_main_conf(ngx_conf_t *cf, void *conf)
     }
 
     ngx_conf_init_uint_value(ctx->filter_max_node, 0);
+
+    ctx->signature = ngx_http_vhost_traffic_status_filter_max_node_signature(ctx);
     ngx_conf_init_value(ctx->enable, 0);
     ngx_conf_init_value(ctx->filter_check_duplicate, vtscf->filter_check_duplicate);
     ngx_conf_init_value(ctx->limit_check_duplicate, vtscf->limit_check_duplicate);

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -390,6 +390,18 @@ typedef struct {
 } ngx_http_vhost_traffic_status_loc_conf_t;
 
 
+/* these take the ctx, which is declared above, so they live here */
+ngx_int_t ngx_http_vhost_traffic_status_node_filter_counted(
+    ngx_http_vhost_traffic_status_ctx_t *ctx,
+    ngx_http_vhost_traffic_status_node_t *vtsn);
+void ngx_http_vhost_traffic_status_node_filter_account(
+    ngx_http_vhost_traffic_status_ctx_t *ctx,
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t delta);
+ngx_int_t ngx_http_vhost_traffic_status_filter_max_node_match_ctx(
+    ngx_http_vhost_traffic_status_ctx_t *ctx, ngx_str_t *filter);
+uint32_t ngx_http_vhost_traffic_status_filter_max_node_signature(
+    ngx_http_vhost_traffic_status_ctx_t *ctx);
+
 ngx_msec_t ngx_http_vhost_traffic_status_current_msec(void);
 ngx_msec_int_t ngx_http_vhost_traffic_status_request_time(ngx_http_request_t *r);
 ngx_msec_int_t ngx_http_vhost_traffic_status_upstream_response_time(ngx_http_request_t *r);

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -277,6 +277,20 @@
 )
 
 
+/*
+   What lives in the zone. The tree is first: shpool->data has always pointed
+   at it, and keeping it there means the pointer still means the same thing
+   to a build that does not know about the rest - which is only reachable on
+   win32, where an existing segment can outlive the binary that made it. The
+   signature will not match there, and the count is made again.
+*/
+typedef struct {
+    ngx_rbtree_t                            rbtree;
+    ngx_atomic_t                            filter_nodes;
+    ngx_atomic_t                            signature;
+} ngx_http_vhost_traffic_status_shm_t;
+
+
 typedef struct {
     ngx_rbtree_t                           *rbtree;
 
@@ -293,6 +307,18 @@ typedef struct {
     ngx_array_t                            *filter_max_node_matches;
 
     ngx_uint_t                              filter_max_node;
+
+    /*
+       What the cap counts, in the zone rather than walked for. signature
+       says which configuration the count belongs to: a reload that changes
+       the cap or the groups it names leaves a count of the wrong population,
+       and the worker that notices counts again. Both are read and written
+       under the mutex of the zone.
+    */
+    ngx_http_vhost_traffic_status_shm_t    *shm;
+
+    /* the signature this configuration expects, settled while it is read */
+    uint32_t                                signature;
 
     ngx_flag_t                              enable;
     ngx_flag_t                              filter_check_duplicate;

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -120,7 +120,8 @@ ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
 /* whether this node is one of the ones the cap counts */
 
 ngx_int_t
-ngx_http_vhost_traffic_status_node_filter_counted(ngx_http_request_t *r,
+ngx_http_vhost_traffic_status_node_filter_counted(
+    ngx_http_vhost_traffic_status_ctx_t *ctx,
     ngx_http_vhost_traffic_status_node_t *vtsn)
 {
     ngx_str_t  filter;
@@ -136,13 +137,54 @@ ngx_http_vhost_traffic_status_node_filter_counted(ngx_http_request_t *r,
         return NGX_DECLINED;
     }
 
-    if (ngx_http_vhost_traffic_status_filter_max_node_match(r, &filter)
+    if (ngx_http_vhost_traffic_status_filter_max_node_match_ctx(ctx, &filter)
         != NGX_OK)
     {
         return NGX_DECLINED;
     }
 
     return NGX_OK;
+}
+
+
+/*
+ * Everything that puts a node into the tree or takes one out comes through
+ * here, with the mutex of the zone held.
+ *
+ * The signature is checked on the way in rather than only where the count is
+ * read. A reload is graceful: for a while the old workers and the new ones
+ * are both serving from this zone, and they do not agree on which nodes the
+ * cap counts. A worker that finds a count belonging to someone else's
+ * configuration must not add to it or take from it - it gives up on the
+ * count instead, and whoever reads it next builds a new one.
+ */
+
+void
+ngx_http_vhost_traffic_status_node_filter_account(
+    ngx_http_vhost_traffic_status_ctx_t *ctx,
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t delta)
+{
+    if (ctx->shm == NULL) {
+        return;
+    }
+
+    if (ctx->shm->signature != ctx->signature) {
+        ctx->shm->signature = 0;
+        return;
+    }
+
+    if (ngx_http_vhost_traffic_status_node_filter_counted(ctx, vtsn)
+        != NGX_OK)
+    {
+        return;
+    }
+
+    if (delta > 0) {
+        ctx->shm->filter_nodes++;
+
+    } else if (ctx->shm->filter_nodes > 0) {
+        ctx->shm->filter_nodes--;
+    }
 }
 
 
@@ -164,7 +206,7 @@ ngx_http_vhost_traffic_status_node_filter_count(ngx_http_request_t *r,
 
     vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
 
-    n = ngx_http_vhost_traffic_status_node_filter_counted(r, vtsn) == NGX_OK
+    n = ngx_http_vhost_traffic_status_node_filter_counted(ctx, vtsn) == NGX_OK
         ? 1 : 0;
 
     return n
@@ -178,6 +220,7 @@ ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
     ngx_str_t *key)
 {
     ngx_str_t                                  filter;
+    ngx_uint_t                                 used;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
 
@@ -218,17 +261,29 @@ ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
      * zone now, under the mutex this is already called with.
      */
 
-    if (ctx->shm->signature != ctx->signature) {
+    if (ctx->shm == NULL) {
 
-        /* the configuration it was made under is not this one */
+        /* nowhere to keep it, so it is counted the way it always was */
 
-        ctx->shm->filter_nodes =
-            ngx_http_vhost_traffic_status_node_filter_count(r, ctx->rbtree->root);
-        ctx->shm->signature = ctx->signature;
+        used = ngx_http_vhost_traffic_status_node_filter_count(r,
+                   ctx->rbtree->root);
+
+    } else {
+        if (ctx->shm->signature != ctx->signature) {
+
+            /* the configuration it was made under is not this one */
+
+            ctx->shm->filter_nodes =
+                ngx_http_vhost_traffic_status_node_filter_count(r,
+                    ctx->rbtree->root);
+            ctx->shm->signature = ctx->signature;
+        }
+
+        used = ctx->shm->filter_nodes;
     }
 
     /* find */
-    if (ctx->shm->filter_nodes >= ctx->filter_max_node) {
+    if (used >= ctx->filter_max_node) {
         node = ngx_http_vhost_traffic_status_find_lru_node(r, NULL, ctx->rbtree->root);
     }
 

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -117,6 +117,62 @@ ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
 }
 
 
+/* whether this node is one of the ones the cap counts */
+
+ngx_int_t
+ngx_http_vhost_traffic_status_node_filter_counted(ngx_http_request_t *r,
+    ngx_http_vhost_traffic_status_node_t *vtsn)
+{
+    ngx_str_t  filter;
+
+    if (vtsn->stat_upstream.type != NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_FG) {
+        return NGX_DECLINED;
+    }
+
+    filter.data = vtsn->data;
+    filter.len = vtsn->len;
+
+    if (ngx_http_vhost_traffic_status_node_position_key(&filter, 1) != NGX_OK) {
+        return NGX_DECLINED;
+    }
+
+    if (ngx_http_vhost_traffic_status_filter_max_node_match(r, &filter)
+        != NGX_OK)
+    {
+        return NGX_DECLINED;
+    }
+
+    return NGX_OK;
+}
+
+
+/* only for the count that a change of configuration has invalidated */
+
+ngx_uint_t
+ngx_http_vhost_traffic_status_node_filter_count(ngx_http_request_t *r,
+    ngx_rbtree_node_t *node)
+{
+    ngx_uint_t                             n;
+    ngx_http_vhost_traffic_status_ctx_t   *ctx;
+    ngx_http_vhost_traffic_status_node_t  *vtsn;
+
+    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+
+    if (node == ctx->rbtree->sentinel) {
+        return 0;
+    }
+
+    vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+
+    n = ngx_http_vhost_traffic_status_node_filter_counted(r, vtsn) == NGX_OK
+        ? 1 : 0;
+
+    return n
+           + ngx_http_vhost_traffic_status_node_filter_count(r, node->left)
+           + ngx_http_vhost_traffic_status_node_filter_count(r, node->right);
+}
+
+
 ngx_rbtree_node_t *
 ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
     ngx_str_t *key)
@@ -124,7 +180,6 @@ ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
     ngx_str_t                                  filter;
     ngx_rbtree_node_t                         *node;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
-    ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
     node = NULL;
@@ -156,16 +211,24 @@ ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r, unsigned type,
         return NULL;
     }
 
-    shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
+    /*
+     * The count used to be made here, by walking the whole tree, before it
+     * had even been compared against the cap - so the walk was paid on every
+     * insertion whether or not the cap was anywhere near. It is kept in the
+     * zone now, under the mutex this is already called with.
+     */
 
-    if (shm_info == NULL) { 
-        return NULL;
+    if (ctx->shm->signature != ctx->signature) {
+
+        /* the configuration it was made under is not this one */
+
+        ctx->shm->filter_nodes =
+            ngx_http_vhost_traffic_status_node_filter_count(r, ctx->rbtree->root);
+        ctx->shm->signature = ctx->signature;
     }
 
-    ngx_http_vhost_traffic_status_shm_info(r, shm_info);
-
     /* find */
-    if (shm_info->filter_used_node >= ctx->filter_max_node) {
+    if (ctx->shm->filter_nodes >= ctx->filter_max_node) {
         node = ngx_http_vhost_traffic_status_find_lru_node(r, NULL, ctx->rbtree->root);
     }
 

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -211,6 +211,10 @@ void ngx_http_vhost_traffic_status_find_name(ngx_http_request_t *r,
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
     ngx_str_t *key, unsigned type, uint32_t key_hash);
 
+ngx_int_t ngx_http_vhost_traffic_status_node_filter_counted(ngx_http_request_t *r,
+    ngx_http_vhost_traffic_status_node_t *vtsn);
+ngx_uint_t ngx_http_vhost_traffic_status_node_filter_count(ngx_http_request_t *r,
+    ngx_rbtree_node_t *node);
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r,
     unsigned type, ngx_str_t *key);
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru_node(ngx_http_request_t *r,

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -211,8 +211,6 @@ void ngx_http_vhost_traffic_status_find_name(ngx_http_request_t *r,
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_node(ngx_http_request_t *r,
     ngx_str_t *key, unsigned type, uint32_t key_hash);
 
-ngx_int_t ngx_http_vhost_traffic_status_node_filter_counted(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn);
 ngx_uint_t ngx_http_vhost_traffic_status_node_filter_count(ngx_http_request_t *r,
     ngx_rbtree_node_t *node);
 ngx_rbtree_node_t *ngx_http_vhost_traffic_status_find_lru(ngx_http_request_t *r,

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -170,8 +170,8 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
             ngx_rbtree_delete(ctx->rbtree, lrun);
             ngx_slab_free_locked(shpool, lrun);
 
-            /* find_lru() only ever gives back one the cap counts */
-            ctx->shm->filter_nodes--;
+            ngx_http_vhost_traffic_status_node_filter_account(ctx,
+                (ngx_http_vhost_traffic_status_node_t *) &lrun->color, -1);
         }
 
         size = offsetof(ngx_rbtree_node_t, color)
@@ -234,11 +234,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
         ngx_rbtree_insert(ctx->rbtree, node);
 
-        if (ngx_http_vhost_traffic_status_node_filter_counted(r, vtsn)
-            == NGX_OK)
-        {
-            ctx->shm->filter_nodes++;
-        }
+        ngx_http_vhost_traffic_status_node_filter_account(ctx, vtsn, 1);
 
     } else {
         init = NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_FIND;

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -169,6 +169,9 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         if (lrun != NULL) {
             ngx_rbtree_delete(ctx->rbtree, lrun);
             ngx_slab_free_locked(shpool, lrun);
+
+            /* find_lru() only ever gives back one the cap counts */
+            ctx->shm->filter_nodes--;
         }
 
         size = offsetof(ngx_rbtree_node_t, color)
@@ -230,6 +233,12 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         ngx_memcpy(vtsn->data, key->data, key->len);
 
         ngx_rbtree_insert(ctx->rbtree, node);
+
+        if (ngx_http_vhost_traffic_status_node_filter_counted(r, vtsn)
+            == NGX_OK)
+        {
+            ctx->shm->filter_nodes++;
+        }
 
     } else {
         init = NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_FIND;

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -167,11 +167,14 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         /* delete lru node */
         lrun = ngx_http_vhost_traffic_status_find_lru(r, type, key);
         if (lrun != NULL) {
-            ngx_rbtree_delete(ctx->rbtree, lrun);
-            ngx_slab_free_locked(shpool, lrun);
+
+            /* while the node is still there to be read */
 
             ngx_http_vhost_traffic_status_node_filter_account(ctx,
                 (ngx_http_vhost_traffic_status_node_t *) &lrun->color, -1);
+
+            ngx_rbtree_delete(ctx->rbtree, lrun);
+            ngx_slab_free_locked(shpool, lrun);
         }
 
         size = offsetof(ngx_rbtree_node_t, color)

--- a/t/039.filter_max_node_count.t
+++ b/t/039.filter_max_node_count.t
@@ -1,0 +1,141 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# vhost_traffic_status_filter_max_node knows how many nodes of the groups it
+# names are in the tree by walking the whole tree, on every insertion, before
+# it has even compared against the cap. Keeping a count instead removes that
+# walk, and these are what say the count is right.
+#
+# They pass on master, which counts by walking and so cannot be wrong. What
+# they are for is the change that stops walking: a count that is not lowered
+# when nodes are deleted leaves the cap thinking the zone is still full, and
+# the eviction starts dropping what it should keep.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * 38;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: the cap keeps the newest of the group it names
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 3 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /f?k=k3',
+    'GET /f?k=k4',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/"k4":\{/,
+]
+--- response_body_unlike eval
+[
+    'nothing',
+    'nothing',
+    'nothing',
+    'nothing',
+    qr/"k1":\{/,
+]
+
+=== TEST 2: deleting the group gives the cap its room back
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 3 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /f?k=k3',
+    'GET /status/control?cmd=delete&group=filter&zone=*',
+    'GET /f?k=k4',
+    'GET /f?k=k5',
+    'GET /f?k=k6',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/"processingCounts":3/,
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/(?=.*"k4":\{)(?=.*"k5":\{)(?=.*"k6":\{)/s,
+]
+
+=== TEST 3: a group the cap does not name is not counted against it
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 2 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /o {
+        vhost_traffic_status_filter_by_set_key $arg_k other::$server_name;
+        return 200 "other:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /o?k=x1',
+    'GET /o?k=x2',
+    'GET /o?k=x3',
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'other:OK',
+    'other:OK',
+    'other:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/(?=.*"k1":\{)(?=.*"k2":\{)/s,
+]
+--- response_body_unlike eval
+[
+    'nothing',
+    'nothing',
+    'nothing',
+    'nothing',
+    'nothing',
+    qr/"x1":\{/,
+]

--- a/t/039.filter_max_node_count.t
+++ b/t/039.filter_max_node_count.t
@@ -12,7 +12,7 @@
 
 use Test::Nginx::Socket;
 
-plan tests => repeat_each() * 38;
+plan tests => repeat_each() * 84;
 no_shuffle();
 run_tests();
 
@@ -46,18 +46,10 @@ __DATA__
     'filter:OK',
     'filter:OK',
     'filter:OK',
-    qr/"k4":\{/,
-]
---- response_body_unlike eval
-[
-    'nothing',
-    'nothing',
-    'nothing',
-    'nothing',
-    qr/"k1":\{/,
+    qr/\A(?=.*"k4":\{)(?!.*"k1":\{)/s,
 ]
 
-=== TEST 2: deleting the group gives the cap its room back
+=== TEST 2: what the eviction took is given back with the rest
 --- http_config
     vhost_traffic_status_zone;
     vhost_traffic_status_filter_max_node 3 g::;
@@ -76,10 +68,12 @@ __DATA__
     'GET /f?k=k1',
     'GET /f?k=k2',
     'GET /f?k=k3',
-    'GET /status/control?cmd=delete&group=filter&zone=*',
     'GET /f?k=k4',
     'GET /f?k=k5',
+    'GET /status/control?cmd=delete&group=filter&zone=*',
     'GET /f?k=k6',
+    'GET /f?k=k7',
+    'GET /f?k=k8',
     'GET /status/format/json',
 ]
 --- response_body_like eval
@@ -87,11 +81,13 @@ __DATA__
     'filter:OK',
     'filter:OK',
     'filter:OK',
+    'filter:OK',
+    'filter:OK',
     qr/"processingCounts":3/,
     'filter:OK',
     'filter:OK',
     'filter:OK',
-    qr/(?=.*"k4":\{)(?=.*"k5":\{)(?=.*"k6":\{)/s,
+    qr/\A(?=.*"k6":\{)(?=.*"k7":\{)(?=.*"k8":\{)/s,
 ]
 
 === TEST 3: a group the cap does not name is not counted against it
@@ -128,14 +124,110 @@ __DATA__
     'other:OK',
     'filter:OK',
     'filter:OK',
-    qr/(?=.*"k1":\{)(?=.*"k2":\{)/s,
+    qr/\A(?=.*"x1":\{)(?=.*"x2":\{)(?=.*"x3":\{)(?=.*"k1":\{)(?=.*"k2":\{)/s,
 ]
---- response_body_unlike eval
+
+=== TEST 4: a named zone an expire does not take is still counted
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 3 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
 [
-    'nothing',
-    'nothing',
-    'nothing',
-    'nothing',
-    'nothing',
-    qr/"x1":\{/,
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /f?k=k3',
+    "GET /status/control?cmd=delete&group=filter&zone=g::localhost\@k1&expire=1h",
+    'GET /f?k=k4',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/"processingCounts":0/,
+    'filter:OK',
+    qr/\A(?=.*"k4":\{)(?=.*"k3":\{)(?!.*"k1":\{)/s,
+]
+
+=== TEST 5: deleting every kind gives the cap its room back too
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 3 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /f?k=k3',
+    'GET /status/control?cmd=delete&group=*',
+    'GET /f?k=k4',
+    'GET /f?k=k5',
+    'GET /f?k=k6',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/"processingReturn":true/,
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/\A(?=.*"k4":\{)(?=.*"k5":\{)(?=.*"k6":\{)/s,
+]
+
+=== TEST 6: a named zone that is taken gives its place back
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_filter_max_node 3 g::;
+--- config
+    location /f {
+        vhost_traffic_status_filter_by_set_key $arg_k g::$server_name;
+        return 200 "filter:OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /f?k=k1',
+    'GET /f?k=k2',
+    'GET /f?k=k3',
+    "GET /status/control?cmd=delete&group=filter&zone=g::localhost\@k1",
+    'GET /f?k=k4',
+    'GET /f?k=k5',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'filter:OK',
+    'filter:OK',
+    'filter:OK',
+    qr/"processingCounts":1/,
+    'filter:OK',
+    'filter:OK',
+    qr/\A(?=.*"k3":\{)(?=.*"k4":\{)(?=.*"k5":\{)/s,
 ]


### PR DESCRIPTION
Closes #376.

`find_lru()` asked `shm_info()` how many nodes of the named groups were in
the tree — which walks all of it — and did so **before** comparing against the
cap. So every insertion paid the walk whether or not the cap was anywhere
near, and the cost is per insertion, which is the shape of traffic the cap
exists for.

## What it costs

A tree of 4000 nodes, a new filter key on every request:

| | master | here |
| --- | --- | --- |
| `filter_max_node 100000`, never reached | 4,624 req/s | **136,082** |
| `filter_max_node 4000`, evicting | 3,902 | **7,712** |

The first row is what the directive costs when it has nothing to do. Without
it at all the same workload runs at 152,387, so that is most of the way back.
What remains in the second row is the walk that looks for the node to evict,
which happens only at the cap and is what an LRU is.

## Where the count lives

In the zone. Workers are processes, so a count in `ctx` would be each
worker's own.

```c
typedef struct {
    ngx_rbtree_t  rbtree;        /* first */
    ngx_atomic_t  filter_nodes;
    ngx_atomic_t  signature;
} ngx_http_vhost_traffic_status_shm_t;
```

The tree is the first member, so `shpool->data` goes on pointing at it and a
build that does not know about the rest still reads a tree there. That matters
only on win32, where `shm.exists` can hand an existing segment to a different
binary — and there the signature will not match, so the count is made again.

## Reload

A reload can change the cap or the groups it names, which changes what the
count is a count of. The count carries a signature of both, and a worker that
finds it stale counts again — under the mutex it already holds.

**The master does nothing.** `init_zone` runs there while the old workers are
still serving from the same zone:

```
SIGHUP → ngx_init_cycle()                     ← init_zone
       → ngx_start_worker_processes()
       → ngx_signal_worker_processes(SHUTDOWN)   ← old workers end here
```

so it must not walk the tree, and taking the zone mutex there would let a
worker that died holding it stop the master. nginx's own modules do not touch
shared data in init either: `limit_req` and `ngx_http_file_cache` compare
configuration and refuse the reload, and `ngx_http_upstream_zone` sidesteps it
with `noreuse = 1`, which this module cannot use — the statistics are the
thing being kept.

## The tests

They pass on master and are meant to. Counting by walking cannot be wrong, so
there is no red to show first.

TEST 2 is the one with teeth: three nodes are made, the group is deleted, and
three more are made. A count that is not lowered on delete leaves the cap
believing the zone is full, and fewer than three survive. TEST 1 and TEST 3
pin what is counted, so the count cannot be made right for the wrong
population.

## Checks

- The rest of the suite is unchanged: file by file, before and after,
  `PASS=25 FAIL=12` both times and the same twelve.
- `t/032`, which covers the scope of the cap, passes.
- Builds clean with and without `--without-http_cache`.
