### PR TITLE
fix: read the backup peers from the group, not from the server lines

### DIFF
--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -14,6 +14,12 @@
 #endif
 
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+static ngx_int_t ngx_http_vhost_traffic_status_control_peer_lookup(
+    ngx_http_upstream_rr_peers_t *peers, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn);
+#endif
+
 static void ngx_http_vhost_traffic_status_node_status_all(
     ngx_http_vhost_traffic_status_control_t *control);
 static void ngx_http_vhost_traffic_status_node_status_group(
@@ -44,6 +50,92 @@ static void ngx_http_vhost_traffic_status_node_reset_zone(
     ngx_http_vhost_traffic_status_control_t *control);
 
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+
+/*
+ * Fills in what the control interface answers with for the peer named `name`,
+ * looking through the peers the upstream group has right now rather than the
+ * server lines it was configured from.
+ *
+ * The backup peers are a list of their own hanging off peers->next and a
+ * `resolve` line makes peers in either of them, so both are walked. Which
+ * list the peer was found in is what says whether it is a backup - a name
+ * resolved at run time is not written down anywhere else.
+ */
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_control_peer_lookup(
+    ngx_http_upstream_rr_peers_t *peers, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn)
+{
+    ngx_int_t                     rc;
+    ngx_uint_t                    backup;
+    ngx_http_upstream_rr_peer_t  *peer;
+
+    rc = NGX_DECLINED;
+
+    for (backup = 0; peers && rc != NGX_OK; peers = peers->next, backup = 1) {
+
+        ngx_http_upstream_rr_peers_rlock(peers);
+
+        for (peer = peers->peer; peer; peer = peer->next) {
+
+            if (peer->name.len != name->len) {
+                continue;
+            }
+
+            if (ngx_strncmp(peer->name.data, name->data, name->len) != 0) {
+                continue;
+            }
+
+#if nginx_version > 1007001
+
+            /*
+             * name rather than peer->name: the name of a peer lives in the
+             * zone of the upstream and a re-resolve can hand it back to the
+             * slab as soon as the lock below is released, while the caller
+             * reads this afterwards to write its answer. The two were just
+             * compared byte for byte, and name belongs to the request.
+             */
+
+            usn->name = *name;
+#endif
+
+            usn->weight = peer->weight;
+            usn->max_fails = peer->max_fails;
+            usn->fail_timeout = peer->fail_timeout;
+            usn->backup = backup;
+
+#if (NGX_HTTP_UPSTREAM_CHECK)
+            usn->down = ngx_http_upstream_check_peer_down(peer->check_index)
+                        ? 1 : 0;
+#else
+
+            /*
+             * max_fails 0 turns the counting off, which nginx reads as never
+             * taking the peer out; without the guard the comparison holds
+             * from the first request and every such peer is called down
+             */
+
+            usn->down = (peer->down
+                         || (peer->max_fails
+                             && peer->fails >= peer->max_fails));
+#endif
+
+            rc = NGX_OK;
+
+            break;
+        }
+
+        ngx_http_upstream_rr_peers_unlock(peers);
+    }
+
+    return rc;
+}
+
+#endif
+
+
 void
 ngx_http_vhost_traffic_status_node_upstream_lookup(
     ngx_http_vhost_traffic_status_control_t *control,
@@ -53,10 +145,6 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
     ngx_str_t                       key, usg, ush;
     ngx_uint_t                      i, j, k;
     ngx_http_upstream_server_t     *us;
-#if (NGX_HTTP_UPSTREAM_ZONE)
-    ngx_http_upstream_rr_peer_t    *peer;
-    ngx_http_upstream_rr_peers_t   *peers;
-#endif
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
 
@@ -118,66 +206,21 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
                  * set. The peers are made by the resolver and live in the
                  * zone, which is where the display reads them since #322.
                  *
-                 * Look there first, and fall back to the server lines, which
-                 * still carry the backup peers - the display splits them the
-                 * same way.
+                 * With a zone those peers are the whole group, backups
+                 * included, so they answer on their own; the server lines are
+                 * all there is to read when there is no zone. This is the
+                 * same source the display reads, which is what keeps the two
+                 * from disagreeing about a peer.
                  */
 
                 if (uscf->shm_zone != NULL) {
-                    peers = uscf->peer.data;
+                    rc = ngx_http_vhost_traffic_status_control_peer_lookup(
+                             uscf->peer.data, &ush, usn);
 
-                    ngx_http_upstream_rr_peers_rlock(peers);
-
-                    for (peer = peers->peer; peer; peer = peer->next) {
-
-                        if (peer->name.len != ush.len) {
-                            continue;
-                        }
-
-                        if (ngx_strncmp(peer->name.data, ush.data, ush.len)
-                            != 0)
-                        {
-                            continue;
-                        }
-
-#if nginx_version > 1007001
-
-                        /*
-                         * ush rather than peer->name: the name of a peer
-                         * lives in the zone of the upstream and a re-resolve
-                         * can hand it back to the slab as soon as the lock
-                         * below is released, while the caller reads this
-                         * afterwards to write its answer. The two were just
-                         * compared byte for byte, and ush belongs to the
-                         * request.
-                         */
-
-                        usn->name = ush;
-#endif
-
-                        usn->weight = peer->weight;
-                        usn->max_fails = peer->max_fails;
-                        usn->fail_timeout = peer->fail_timeout;
-                        usn->backup = 0;
-
-#if (NGX_HTTP_UPSTREAM_CHECK)
-                        usn->down = ngx_http_upstream_check_peer_down(
-                                        peer->check_index) ? 1 : 0;
-#else
-                        usn->down = (peer->down
-                                     || (peer->max_fails
-                                         && peer->fails >= peer->max_fails));
-#endif
-
+                    if (rc == NGX_OK) {
                         control->count++;
-
-                        break;
                     }
 
-                    ngx_http_upstream_rr_peers_unlock(peers);
-                }
-
-                if (control->count) {
                     break;
                 }
 

--- a/src/ngx_http_vhost_traffic_status_display.c
+++ b/src/ngx_http_vhost_traffic_status_display.c
@@ -596,15 +596,29 @@ ngx_http_vhost_traffic_status_display_get_upstream_nelts(ngx_http_request_t *r)
                 goto not_supported;
             }
 
-            peers = uscf->peer.data;
+            /*
+             * Both lists, and the server lines are not read at all: this has
+             * to count what display_set_upstream_group() writes. Counting the
+             * primary peers and then every server line was slack while the
+             * backups came from the lines, and it stopped being slack when
+             * they started coming from peers->next. A name that resolves to
+             * more addresses than the one placeholder its line leaves behind
+             * is then written without having been counted, and the entries
+             * that do not fit are dropped by display_buffer_check().
+             */
 
-            ngx_http_upstream_rr_peers_rlock(peers);
+            for (peers = uscf->peer.data; peers; peers = peers->next) {
 
-            for (peer = peers->peer; peer; peer = peer->next) {
-                n++;
+                ngx_http_upstream_rr_peers_rlock(peers);
+
+                for (peer = peers->peer; peer; peer = peer->next) {
+                    n++;
+                }
+
+                ngx_http_upstream_rr_peers_unlock(peers);
             }
 
-            ngx_http_upstream_rr_peers_unlock(peers);
+            continue;
 
 not_supported:
 

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -1105,7 +1105,7 @@ ngx_http_vhost_traffic_status_display_resolves(ngx_http_request_t *r)
 {
     ngx_uint_t                                i;
     ngx_array_t                              *resolves;
-    ngx_http_upstream_rr_peers_t             *peers;
+    ngx_http_upstream_rr_peers_t             *peers, *rpeers;
     ngx_http_upstream_srv_conf_t             *uscf, **uscfp;
     ngx_http_upstream_main_conf_t            *umcf;
     ngx_http_vhost_traffic_status_resolve_t  *rs;
@@ -1123,9 +1123,24 @@ ngx_http_vhost_traffic_status_display_resolves(ngx_http_request_t *r)
             continue;
         }
 
+        /*
+         * Either list can be the one that resolves: nginx builds a resolve
+         * list for the backup servers as well, so a group whose only
+         * resolving line is a backup has peers->resolve == NULL and a
+         * peers->next->resolve. Reading the primary list alone skips such a
+         * group, and what a replaced backup served stays in the tree with
+         * nothing pointing at it.
+         */
+
         peers = uscf->peer.data;
 
-        if (peers->resolve == NULL) {
+        for (rpeers = peers; rpeers; rpeers = rpeers->next) {
+            if (rpeers->resolve != NULL) {
+                break;
+            }
+        }
+
+        if (rpeers == NULL) {
             continue;
         }
 

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -620,6 +620,7 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
     ngx_rbtree_node_t                     *node;
     ngx_http_upstream_server_t            *us, usn;
 #if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_uint_t                             backup;
     ngx_http_upstream_rr_peer_t           *peer;
     ngx_http_upstream_rr_peers_t          *peers;
 #endif
@@ -691,76 +692,85 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
 
             peers = uscf->peer.data;
 
-            ngx_http_upstream_rr_peers_rlock(peers);
+            /*
+             * A peer that a `resolve` line makes at run time is not named by
+             * any server line, and nginx builds a resolve list for the backup
+             * servers too. Both lists are walked, and the flag comes from the
+             * one the peer was found in - the server lines cannot say it here.
+             */
+            for (backup = 0; peers; peers = peers->next, backup = 1) {
 
-            for (peer = peers->peer; peer; peer = peer->next) {
-                dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
-                dst.data = ngx_pnalloc(r->pool, dst.len);
-                if (dst.data == NULL) {
-                    ngx_http_upstream_rr_peers_unlock(peers);
-                    return buf;
-                }
+                ngx_http_upstream_rr_peers_rlock(peers);
 
-                p = dst.data;
-                p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
-                *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
-                p = ngx_cpymem(p, peer->name.data, peer->name.len);
+                for (peer = peers->peer; peer; peer = peer->next) {
+                    dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
+                    dst.data = ngx_pnalloc(r->pool, dst.len);
+                    if (dst.data == NULL) {
+                        ngx_http_upstream_rr_peers_unlock(peers);
+                        return buf;
+                    }
 
-                rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
-                if (rc != NGX_OK) {
-                    ngx_http_upstream_rr_peers_unlock(peers);
-                    return buf;
-                }
+                    p = dst.data;
+                    p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
+                    *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
+                    p = ngx_cpymem(p, peer->name.data, peer->name.len);
 
-                hash = ngx_crc32_short(key.data, key.len);
-                node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
+                    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
+                    if (rc != NGX_OK) {
+                        ngx_http_upstream_rr_peers_unlock(peers);
+                        return buf;
+                    }
 
-                usn.weight = peer->weight;
-                usn.max_fails = peer->max_fails;
-                usn.fail_timeout = peer->fail_timeout;
-                usn.backup = 0;
+                    hash = ngx_crc32_short(key.data, key.len);
+                    node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
+
+                    usn.weight = peer->weight;
+                    usn.max_fails = peer->max_fails;
+                    usn.fail_timeout = peer->fail_timeout;
+                    usn.backup = backup;
 #if (NGX_HTTP_UPSTREAM_CHECK)
-                if (ngx_http_upstream_check_peer_down(peer->check_index)) {
-                    usn.down = 1;
+                    if (ngx_http_upstream_check_peer_down(peer->check_index)) {
+                        usn.down = 1;
 
-                } else {
-                    usn.down = 0;
+                    } else {
+                        usn.down = 0;
+                    }
+#else
+                    /*
+                     * max_fails 0 turns the counting off, which nginx reads as
+                     * never taking the peer out; without the guard the comparison
+                     * holds from the first request and every such peer is called
+                     * down
+                     */
+                    usn.down = (peer->down
+                                || (peer->max_fails
+                                    && peer->fails >= peer->max_fails));
+#endif
+
+#if nginx_version > 1007001
+                    usn.name = peer->name;
+#endif
+
+                    if (node != NULL) {
+                        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
+#if nginx_version > 1007001
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn);
+#else
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn, &peer->name);
+#endif
+
+                    } else {
+#if nginx_version > 1007001
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL);
+#else
+                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL, &peer->name);
+#endif
+                    }
+
                 }
-#else
-                /*
-                 * max_fails 0 turns the counting off, which nginx reads as
-                 * never taking the peer out; without the guard the comparison
-                 * holds from the first request and every such peer is called
-                 * down
-                 */
-                usn.down = (peer->down
-                            || (peer->max_fails
-                                && peer->fails >= peer->max_fails));
-#endif
 
-#if nginx_version > 1007001
-                usn.name = peer->name;
-#endif
-
-                if (node != NULL) {
-                    vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
-#if nginx_version > 1007001
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn);
-#else
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn, &peer->name);
-#endif
-
-                } else {
-#if nginx_version > 1007001
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL);
-#else
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL, &peer->name);
-#endif
-                }
-
+                ngx_http_upstream_rr_peers_unlock(peers);
             }
-
-            ngx_http_upstream_rr_peers_unlock(peers);
 
 #if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
             /*
@@ -784,12 +794,14 @@ not_supported:
 
 #endif
 
-            for (j = 0; j < uscf->servers->nelts; j++) {
+            /*
+             * The server lines are read only when there is no zone to read
+             * instead. They used to supply the backup peers, which is where
+             * a resolving line went missing: it leaves an address whose name
+             * was never set, so what came out was an empty server name.
+             */
+            for (j = 0; !zone && j < uscf->servers->nelts; j++) {
                 usn = us[j];
-
-                if (zone && usn.backup != 1) {
-                    continue;
-                }
 
                 /* for all A records */
                 for (k = 0; k < usn.naddrs; k++) {

--- a/t/040.upstream_backup_resolve.t
+++ b/t/040.upstream_backup_resolve.t
@@ -1,0 +1,273 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The `resolve` parameter of the upstream server directive needs nginx 1.27.3
+# or later, freenginx does not have it.
+#
+# nginx builds a resolve list for the backup servers too, so a line reading
+# `server name:port resolve backup` gets its peers at run time like any other.
+# Those peers live in peers->next, and neither reader walks it: the display
+# takes the primary peers from peers->peer and the backups from the server
+# lines, where a resolving line leaves an address whose name was never set.
+#
+# The statistics are keyed on the name of the peer that served the request, so
+# the node is in the tree. What comes out is an entry with an empty server name
+# and no counters, and a control interface that answers with nothing.
+
+use Test::Nginx::Socket;
+use Socket;
+use POSIX ();
+
+my $nginx = $ENV{TEST_NGINX_BINARY} || 'nginx';
+my $version = `$nginx -v 2>&1` || '';
+my $supported = 0;
+
+if ($version =~ m{^nginx version: nginx/(\d+)\.(\d+)\.(\d+)}) {
+    $supported = ($1 * 1000000 + $2 * 1000 + $3) >= 1027003;
+}
+
+plan skip_all => "upstream resolve is not supported by: $version"
+    unless $supported;
+
+# the test resolver
+
+my $DNSPort    = 18656;
+my $FirstAddr  = '127.0.0.1';   # port 1984 of the test server answers here
+my $SecondAddr = '127.0.0.1';   # the name keeps one address for these tests
+my $SwitchIn   = 3600;
+
+# Sends a query and tells whether the test resolver answers it.
+sub dns_ready {
+    my $sock;
+
+    socket($sock, PF_INET, SOCK_DGRAM, getprotobyname('udp')) or return 0;
+
+    my $to = sockaddr_in($DNSPort, inet_aton('127.0.0.1'));
+    my $query = pack('n n n n n n', 0x2a2a, 0x0100, 1, 0, 0, 0)
+                . join('', map { chr(length $_) . $_ } qw(vts-test example))
+                . "\0" . pack('n n', 1, 1);
+
+    for (1 .. 30) {
+        next unless send($sock, $query, 0, $to);
+
+        my $rin = '';
+        vec($rin, fileno($sock), 1) = 1;
+
+        if (select($rin, undef, undef, 0.1)) {
+            my $answer;
+            recv($sock, $answer, 512, 0);
+            close $sock;
+            return 1;
+        }
+    }
+
+    close $sock;
+
+    return 0;
+}
+
+# The resolver runs as its own process: a plain fork of the test is not safe
+# on every platform.
+my $dns_pid = fork();
+
+defined $dns_pid or plan skip_all => "fork() failed: $!";
+
+if ($dns_pid == 0) {
+    my $server = __FILE__;
+    $server =~ s{[^/]+$}{dns_server.pl};
+
+    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
+        or POSIX::_exit(1);
+}
+
+END {
+    if ($dns_pid) {
+        local $?;
+
+        kill 'TERM', $dns_pid;
+        waitpid($dns_pid, 0);
+    }
+}
+
+plan skip_all => "the test resolver does not answer on 127.0.0.1:$DNSPort"
+    unless dns_ready();
+
+plan tests => repeat_each() * 26;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: a backup peer the resolver made is named in the display
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18656 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1 down;
+        server vts-test.example:1984 resolve backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"upstreamZones".*"server":"127\.0\.0\.1:1984"(?:(?!"server":).)*"backup":true/s,
+]
+
+=== TEST 2: its statistics are counted against that name
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18656 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1 down;
+        server vts-test.example:1984 resolve backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /up',
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    'OK',
+    'OK',
+    qr/"server":"127\.0\.0\.1:1984"(?:(?!"server":).)*"requestCounter":2/s,
+]
+
+=== TEST 3: the control interface finds it
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18656 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1 down;
+        server vts-test.example:1984 resolve backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    "GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1984",
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"server":"127\.0\.0\.1:1984".*"requestCounter":1.*"backup":true/s,
+]
+
+=== TEST 4: a backup that does not resolve is still named, and still backup
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1 down;
+        server 127.0.0.1:1984 backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /status/format/json',
+    "GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1984",
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"server":"127\.0\.0\.1:1984"(?:(?!"server":).)*"requestCounter":1(?:(?!"server":).)*"backup":true/s,
+    qr/"server":"127\.0\.0\.1:1984".*"backup":true/s,
+]
+
+=== TEST 5: a primary is not called backup because a backup list exists
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1984;
+        server 127.0.0.1:1 backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /up',
+    'GET /status/format/json',
+    "GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1984",
+]
+--- response_body_like eval
+[
+    'OK',
+    qr/"server":"127\.0\.0\.1:1984"(?:(?!"server":).)*"backup":false/s,
+    qr/"server":"127\.0\.0\.1:1984".*"backup":false/s,
+]

--- a/t/040.upstream_backup_resolve.t
+++ b/t/040.upstream_backup_resolve.t
@@ -31,17 +31,23 @@ plan skip_all => "upstream resolve is not supported by: $version"
 # the test resolver
 
 my $DNSPort    = 18656;
+my $WidePort   = 18658;   # a resolver whose answers carry many addresses
 my $FirstAddr  = '127.0.0.1';   # port 1984 of the test server answers here
 my $SecondAddr = '127.0.0.1';   # the name keeps one address for these tests
 my $SwitchIn   = 3600;
 
 # Sends a query and tells whether the test resolver answers it.
+# The addresses the wide name stands for. One server line, many peers.
+my @Wide = map { sprintf('127.0.%d.%d', int($_ / 250) + 1, $_ % 250 + 1) }
+           0 .. 119;
+
 sub dns_ready {
+    my ($port) = @_;
     my $sock;
 
     socket($sock, PF_INET, SOCK_DGRAM, getprotobyname('udp')) or return 0;
 
-    my $to = sockaddr_in($DNSPort, inet_aton('127.0.0.1'));
+    my $to = sockaddr_in($port, inet_aton('127.0.0.1'));
     my $query = pack('n n n n n n', 0x2a2a, 0x0100, 1, 0, 0, 0)
                 . join('', map { chr(length $_) . $_ } qw(vts-test example))
                 . "\0" . pack('n n', 1, 1);
@@ -65,33 +71,42 @@ sub dns_ready {
     return 0;
 }
 
-# The resolver runs as its own process: a plain fork of the test is not safe
-# on every platform.
-my $dns_pid = fork();
+# The resolvers run as their own processes: a plain fork of the test is not
+# safe on every platform.
+my @dns_pids;
 
-defined $dns_pid or plan skip_all => "fork() failed: $!";
+for my $r ([$DNSPort, $FirstAddr, $SecondAddr], [$WidePort, $Wide[0], $Wide[0], @Wide[1 .. $#Wide]]) {
+    my $pid = fork();
 
-if ($dns_pid == 0) {
-    my $server = __FILE__;
-    $server =~ s{[^/]+$}{dns_server.pl};
+    defined $pid or plan skip_all => "fork() failed: $!";
 
-    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
-        or POSIX::_exit(1);
+    if ($pid == 0) {
+        my $server = __FILE__;
+        $server =~ s{[^/]+$}{dns_server.pl};
+
+        my ($port, @addrs) = @$r;
+
+        exec($^X, $server, $port, $SwitchIn, @addrs) or POSIX::_exit(1);
+    }
+
+    push @dns_pids, $pid;
 }
 
 END {
-    if ($dns_pid) {
-        local $?;
+    local $?;
 
-        kill 'TERM', $dns_pid;
-        waitpid($dns_pid, 0);
+    for my $pid (@dns_pids) {
+        kill 'TERM', $pid;
+        waitpid($pid, 0);
     }
 }
 
-plan skip_all => "the test resolver does not answer on 127.0.0.1:$DNSPort"
-    unless dns_ready();
+for my $port ($DNSPort, $WidePort) {
+    plan skip_all => "the test resolver does not answer on 127.0.0.1:$port"
+        unless dns_ready($port);
+}
 
-plan tests => repeat_each() * 26;
+plan tests => repeat_each() * 28;
 no_shuffle();
 run_tests();
 
@@ -270,4 +285,31 @@ __DATA__
     'OK',
     qr/"server":"127\.0\.0\.1:1984"(?:(?!"server":).)*"backup":false/s,
     qr/"server":"127\.0\.0\.1:1984".*"backup":false/s,
+]
+
+=== TEST 6: every peer a wide name stands for is written, none dropped
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18658 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream wide {
+        zone wide 1m;
+        server 127.0.0.1:1984;
+        server wide.example:1984 resolve backup;
+    }
+--- config
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+[
+    'GET /status/format/json',
+]
+--- response_body_like eval
+[
+    qr/"server":"127\.0\.1\.120:1984"/s,
 ]

--- a/t/041.upstream_backup_gone.t
+++ b/t/041.upstream_backup_gone.t
@@ -1,0 +1,137 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The `resolve` parameter of the upstream server directive needs nginx 1.27.3
+# or later, freenginx does not have it.
+#
+# A peer that a re-resolve takes out of its upstream group keeps its statistics
+# in the tree, and the display writes them after the peers the group has now
+# (#357). A group is enrolled in that only when the primary list resolves:
+#
+#     peers = uscf->peer.data;
+#
+#     if (peers->resolve == NULL) {
+#         continue;
+#     }
+#
+# nginx builds a resolve list for the backup servers too, so a group whose only
+# resolving line is a backup has peers->resolve == NULL while
+# peers->next->resolve is not. It is skipped, and what the replaced backup
+# served is in the tree with nothing pointing at it.
+#
+# This file has its own resolver because the answer changes on a timer that
+# starts when the resolver does: a block that has to run before the change
+# cannot share one with blocks that run for an unknown length of time first.
+
+use Test::Nginx::Socket;
+use Socket;
+use POSIX ();
+
+my $nginx = $ENV{TEST_NGINX_BINARY} || 'nginx';
+my $version = `$nginx -v 2>&1` || '';
+my $supported = 0;
+
+if ($version =~ m{^nginx version: nginx/(\d+)\.(\d+)\.(\d+)}) {
+    $supported = ($1 * 1000000 + $2 * 1000 + $3) >= 1027003;
+}
+
+plan skip_all => "upstream resolve is not supported by: $version"
+    unless $supported;
+
+# the test resolver
+
+my $DNSPort    = 18661;
+my $FirstAddr  = '127.0.0.1';   # port 1984 of the test server answers here
+my $SecondAddr = '127.0.0.2';   # and here, the peer is replaced by the name
+my $SwitchIn   = 4;             # seconds until the name gets the second address
+
+# Sends a query and tells whether the test resolver answers it.
+sub dns_ready {
+    my $sock;
+
+    socket($sock, PF_INET, SOCK_DGRAM, getprotobyname('udp')) or return 0;
+
+    my $to = sockaddr_in($DNSPort, inet_aton('127.0.0.1'));
+    my $query = pack('n n n n n n', 0x2a2a, 0x0100, 1, 0, 0, 0)
+                . join('', map { chr(length $_) . $_ } qw(vts-test example))
+                . "\0" . pack('n n', 1, 1);
+
+    for (1 .. 30) {
+        next unless send($sock, $query, 0, $to);
+
+        my $rin = '';
+        vec($rin, fileno($sock), 1) = 1;
+
+        if (select($rin, undef, undef, 0.1)) {
+            my $answer;
+            recv($sock, $answer, 512, 0);
+            close $sock;
+            return 1;
+        }
+    }
+
+    close $sock;
+
+    return 0;
+}
+
+# The resolver runs as its own process: a plain fork of the test is not safe
+# on every platform.
+my $dns_pid = fork();
+
+defined $dns_pid or plan skip_all => "fork() failed: $!";
+
+if ($dns_pid == 0) {
+    my $server = __FILE__;
+    $server =~ s{[^/]+$}{dns_server.pl};
+
+    exec($^X, $server, $DNSPort, $SwitchIn, $FirstAddr, $SecondAddr)
+        or POSIX::_exit(1);
+}
+
+END {
+    if ($dns_pid) {
+        local $?;
+
+        kill 'TERM', $dns_pid;
+        waitpid($dns_pid, 0);
+    }
+}
+
+plan skip_all => "the test resolver does not answer on 127.0.0.1:$DNSPort"
+    unless dns_ready();
+
+plan tests => repeat_each() * 4;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: a backup a re-resolve took out keeps its statistics
+--- http_config
+    vhost_traffic_status_zone;
+
+    resolver 127.0.0.1:18661 valid=1s ipv6=off;
+    resolver_timeout 2s;
+
+    upstream backend {
+        zone backend 1m;
+        server 127.0.0.1:1 down;
+        server vts-test.example:1984 resolve backup;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- wait: 6
+--- request eval
+['GET /up', 'GET /status/format/json']
+--- response_body_like eval
+['OK', qr/(?=.*"server":"127\.0\.0\.2:1984")(?=.*\{"server":"127\.0\.0\.1:1984","requestCounter":[1-9])(?=.*"127\.0\.0\.1:1984".*?"down":true)/s]

--- a/t/dns_server.pl
+++ b/t/dns_server.pl
@@ -5,14 +5,17 @@
 # `switch` seconds have passed, so that the peers of an upstream group get
 # replaced while the test is running.
 #
-# usage: dns_server.pl <port> <switch> <first address> <second address>
+# Any address after the second one is added to every answer, for the tests that
+# need a name to stand for more peers than the server line that holds it.
+#
+# usage: dns_server.pl <port> <switch> <first address> <second address> [more]
 
 use strict;
 use warnings;
 
 use Socket;
 
-my ($port, $switch, $first, $second) = @ARGV;
+my ($port, $switch, $first, $second, @rest) = @ARGV;
 
 die "usage: $0 <port> <switch> <first address> <second address>\n"
     unless defined $second;
@@ -76,10 +79,12 @@ while (1) {
     if ($qtype == 1) {          # A
         my $address = (time() - $started) >= $switch ? $second : $first;
 
-        # name pointer, type A, class IN, ttl, rdlength, address
-        $answer = pack('n n n N n a4', 0xc00c, 1, 1, 1, 4,
-                       inet_aton($address));
-        $ancount = 1;
+        for my $a ($address, @rest) {
+            # name pointer, type A, class IN, ttl, rdlength, address
+            $answer .= pack('n n n N n a4', 0xc00c, 1, 1, 1, 4,
+                            inet_aton($a));
+            $ancount++;
+        }
     }
 
     # id, flags (response, recursion available), section counts


### PR DESCRIPTION
Closes #382.

## The problem

`server name:port resolve backup` never shows up.

nginx builds a resolve list for the backup servers too, so a resolving backup
line gets its peers from the resolver like any other line. Those peers live in
`peers->next`, which neither reader walked:

- the display took the primaries from `peers->peer` and the backups from
  `uscf->servers`
- the control interface looked at `peers->peer` first (#381) and fell back to
  `uscf->servers`

A resolving server line has no address to give: `ngx_http_upstream_server()`
keeps a placeholder holding the port, and `addrs[0].name` is never set.

Measured on nginx 1.30.4, with an upstream whose backup serves the request:

| | master |
| --- | --- |
| the node in the tree | `UG␟be␟127.0.0.1:18808`, present |
| `upstreamZones` | `"server":""`, `"backup":true`, every counter 0 |
| `?cmd=status&group=upstream@group&zone=be@127.0.0.1:18808` | `{}` |

So the peer is not merely missing from the output: an entry with an empty name
is printed in its place, and the statistics that are in the tree cannot be
reached from either side.

## The change

Both readers walk `peers->next` as well, and take `backup` from the list the
peer was found in rather than assuming 0 (display) or reading it off the server
line (control). A name resolved at run time is not written down anywhere else.

With a zone the peer lists are the whole group, so the server lines are now read
only when there is no zone to read instead. That is what keeps the display and
the control interface on the same source, the principle that decided #381 too.

The control walk moved into a function of its own. It was already four levels
deep and one more would have put the body past the margin; the unlock has a
single exit there. The display change is the existing body indented inside a new
outer loop, so `git diff -w` shows the four lines that actually changed.

## Tests

`t/040.upstream_backup_resolve.t`, 26 assertions.

TEST 1-3 are the bug: a resolved backup is named in the display, its counters
are counted against that name, and the control interface finds it. TEST 4-5 hold
what is already right, so that the change to the server lines cannot go
unnoticed: a backup that does not resolve keeps its name and its flag, and a
primary is not called backup because a backup list happens to exist.

The same nginx build, before and after:

```
master:  Tests: 26 Failed: 3   (TEST 1, 2, 3)
fixed:   Tests: 26 Failed: 0
```

CI here runs on pull requests rather than on branch pushes, so the test is kept
in its own commit for anyone who wants to watch it fail alone.

## Worth naming

A `resolve` line whose name has not been answered yet used to print
`"server":""`. It now prints nothing until the name resolves, which is what the
rest of the resolve support already does.

Also checked: an upstream without a zone gives byte-identical output, and the
module builds with `-Werror` under `--without-http_upstream_zone_module`, which
CI does not cover.

## Added after review

Copilot found two more things, both measured and both fixed here.

**The buffer this output goes into was still sized from the primary peers plus
every server line.** That was slack while the backups came from the lines, and
it stopped being slack the moment they started coming from `peers->next`: a name
resolving to more addresses than the one placeholder its line leaves behind is
written without having been counted. The entries that no longer fit are not
written past the end - `buffer_check()` catches them - they are dropped, and
**the output stays valid JSON with peers missing from it**, so checking the
syntax does not catch it. With a resolving backup standing for 100 addresses, on
a zone whose tree held two nodes: 101 peers expected, 81 written, 20 lines of
`not enough buffer` in the error log. `get_upstream_nelts()` now walks both
lists and reads no server lines when there is a zone, matching the writer.
`t/040` TEST 6 covers it, and the test resolver takes further addresses so a
name can stand for more peers than its server line.

**A group whose only resolving line is a backup was not enrolled in gone-peer
tracking** (#385). `display_resolves()` read `peers->resolve` of the primary
list alone, so a replaced backup left its statistics in the tree with nothing
pointing at it:

| | before the answer changes | after |
| --- | --- | --- |
| `usedNode` | 2 | 3 |
| `upstreamZones` | `127.0.0.1:1984`, requestCounter 1 | `127.0.0.2:1984`, requestCounter 1 |

The search now looks at both lists, through a pointer of its own: `peers` is
handed to `display_upstream_peer_names()` afterwards, and walking it to the list
that resolves would have collected that list's names only, so every primary peer
with a node would have read as gone and been written twice. `t/041` covers it,
in a file of its own because the answer changes on a timer that starts with the
resolver.

The third finding is answered in its thread: the `backup` flag of a gone peer
cannot be restored, because nothing records which list a peer that is in neither
list used to be in. Its `weight` and `maxFails` read 0 for the same reason.
