### PR TITLE
test: cover the two files the suite never executed, and measure it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,99 @@ jobs:
         working-directory: nginx-module-vts
         run: sudo tail -n 100 t/servroot/logs/error.log || true
 
+  coverage:
+    name: 'coverage'
+    runs-on: ubuntu-24.04
+    permissions:
+      # the badge is a single file force pushed to the `badges` branch, and
+      # the summary is left on the pull request as one comment that later runs
+      # replace
+      contents: write
+      pull-requests: write
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: nginx-module-vts
+      - name: 'checkout nginx'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: nginx/nginx
+          path: nginx
+          ref: '017cf98dcce217946572a896f0992370475e189f'
+      - name: 'prepare cpanm'
+        run: |
+          sudo apt install -y cpanminus gcovr
+          sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
+      - name: 'prepare promtool'
+        env:
+          # pinned, for the reason given in the job above
+          PROMETHEUS_VERSION: '3.13.2'
+        run: |
+          curl -fsSL -o prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar xzf prometheus.tar.gz
+          sudo mv prometheus-*/promtool /usr/local/bin
+          promtool --version
+      - name: 'build nginx with coverage'
+        working-directory: nginx
+        run: |
+          # -O0 so that the arcs the counters are attached to still match the
+          # lines they were written for
+          ./auto/configure \
+            --prefix=/usr/local/nginx-cov \
+            --add-module=/home/runner/work/nginx-module-vts/nginx-module-vts/nginx-module-vts \
+            --with-cc-opt="--coverage -O0" \
+            --with-ld-opt="--coverage"
+          make -j$(nproc)
+          sudo make install
+          /usr/local/nginx-cov/sbin/nginx -V
+      - name: 'test'
+        working-directory: nginx-module-vts
+        run: |
+          # the lua tests need modules that are not part of this build
+          sudo PATH=/usr/local/nginx-cov/sbin:$PATH prove $(ls t/*.t | grep -v '_by_lua')
+      - name: 'collect'
+        run: |
+          # the workers run as root and leave their counters behind as root
+          sudo chown -R "$(id -u):$(id -g)" nginx/objs
+          gcovr --root "$GITHUB_WORKSPACE/nginx-module-vts" \
+                --filter "$GITHUB_WORKSPACE/nginx-module-vts/src/" \
+                --cobertura "$GITHUB_WORKSPACE/coverage.xml" \
+                --print-summary \
+                "$GITHUB_WORKSPACE/nginx/objs/addon/src"
+      - name: 'summarise'
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
+        with:
+          filename: coverage.xml
+          badge: true
+          format: markdown
+          hide_complexity: true
+          output: both
+          thresholds: '60 80'
+      - name: 'add the summary to the run'
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+      - name: 'comment on the pull request'
+        # a pull request from a fork is handed a read only token, so the
+        # comment cannot be written and the run summary is where to read it
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: coverage
+          recreate: true
+          path: code-coverage-results.md
+      - name: 'publish the badge'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: nginx-module-vts/util/coverage-badge.sh coverage.xml
+      - name: 'dump nginx error log'
+        if: failure()
+        working-directory: nginx-module-vts
+        run: sudo tail -n 100 t/servroot/logs/error.log || true
+
   build-variants:
     name: 'build (${{ matrix.variant.name }})'
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 t/servroot
 front/dist
 front/node_modules
+t/vts.dump

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Nginx virtual host traffic status module
 ==========
 
 [![CI](https://github.com/vozlt/nginx-module-vts/actions/workflows/ci.yml/badge.svg)](https://github.com/vozlt/nginx-module-vts/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vozlt/nginx-module-vts/badges/coverage.json)](https://github.com/vozlt/nginx-module-vts/actions/workflows/ci.yml)
 [![License](http://img.shields.io/badge/license-BSD-brightgreen.svg)](https://github.com/vozlt/nginx-module-vts/blob/master/LICENSE)
 
 Nginx virtual host traffic status module

--- a/t/042.dump.t
+++ b/t/042.dump.t
@@ -1,0 +1,114 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# vhost_traffic_status_dump writes the tree to a file on a timer and reads it
+# back when a worker starts, so that a restart does not lose what was measured.
+# Nothing in the suite configured the directive, which left every line of
+# ngx_http_vhost_traffic_status_dump.c unexecuted - the write, the restore, and
+# the two places recent work touched inside them: the last-seen time a restored
+# node is given (#375) and the filter count a restored node is added to (#383).
+#
+# The file is kept outside the server root. Test::Nginx builds that directory
+# again for every block that changes the configuration, and a dump written
+# under it would be thrown away with it - which is exactly what the restore
+# needs to survive. It is removed before the run as well: a dump left by an
+# earlier one would be read into the first block, and the counters would start
+# from a number this file did not put there.
+
+use Test::Nginx::Socket;
+use File::Spec ();
+
+my $DumpFile = File::Spec->rel2abs('t/vts.dump');
+
+$ENV{TEST_NGINX_DUMP_FILE} = $DumpFile;
+
+unlink $DumpFile;
+
+add_cleanup_handler(sub { unlink $DumpFile });
+
+plan tests => repeat_each() * 12;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: what a worker measured is written to the dump file
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- wait: 2
+--- request eval
+['GET /ok', 'GET /status/format/json']
+--- response_body_like eval
+['OK', qr/"localhost":\{"requestCounter":1/]
+
+=== TEST 2: a worker that starts finds it and reads it back
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /restarted {
+        return 200 "restarted";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /status/format/json']
+--- response_body_like eval
+[qr/"localhost":\{"requestCounter":[2-9]/]
+
+=== TEST 3: the restored nodes are counted, not just written out
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /restarted-again {
+        return 200 "restarted";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /status/format/json']
+--- response_body_like eval
+[qr/"usedNode":[1-9]/]
+
+=== TEST 4: a restored node keeps taking traffic
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /once-more {
+        return 200 "restarted";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /ok', 'GET /status/format/json']
+--- response_body_like eval
+['OK', qr/"localhost":\{"requestCounter":[3-9]/]

--- a/t/043.variables.t
+++ b/t/043.variables.t
@@ -1,0 +1,101 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The $vts_* variables are read straight from the node of the server zone that
+# handled the request. The only test that touched them went through
+# ngx_http_lua_module (t/015), so a build without lua left
+# ngx_http_vhost_traffic_status_variables.c almost entirely unexecuted - and
+# the variables are meant to be used from an ordinary configuration, in
+# add_header, log_format or proxy_set_header, with no lua anywhere.
+#
+# The cache variables are not used here on purpose: they are declared inside
+# #if (NGX_HTTP_CACHE), so naming one would keep this file from starting on a
+# build configured with --without-http-cache.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * 24;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: nothing to read before the zone has a node, numbers after
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /v {
+        add_header X-Req-Counter $vts_request_counter;
+        add_header X-In-Bytes $vts_in_bytes;
+        add_header X-Out-Bytes $vts_out_bytes;
+        add_header X-2xx $vts_2xx_counter;
+        return 200 "OK";
+    }
+--- request eval
+['GET /v', 'GET /v', 'GET /v']
+--- response_body_like eval
+['OK', 'OK', 'OK']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Req-Counter)/s,
+    qr/X-Req-Counter: 1\b.*X-In-Bytes: [1-9]\d*.*X-Out-Bytes: [1-9]\d*.*X-2xx: 1\b/s,
+    qr/X-Req-Counter: 2\b.*X-2xx: 2\b/s,
+]
+
+=== TEST 2: the request time is the average of the queue, and has its own counter
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /v {
+        add_header X-Req-Time $vts_request_time;
+        add_header X-Req-Time-Counter $vts_request_time_counter;
+        add_header X-5xx $vts_5xx_counter;
+        return 200 "OK";
+    }
+--- request eval
+['GET /v', 'GET /v']
+--- response_body_like eval
+['OK', 'OK']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Req-Time)/s,
+    qr/X-Req-Time: \d+\b.*X-Req-Time-Counter: \d+\b.*X-5xx: 0\b/s,
+]
+
+=== TEST 3: each server zone is read from its own node
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1984;
+        server_name vts-other;
+
+        location /v {
+            add_header X-Req-Counter $vts_request_counter;
+            return 200 "other";
+        }
+    }
+--- config
+    location /v {
+        add_header X-Req-Counter $vts_request_counter;
+        return 200 "OK";
+    }
+--- request eval
+[
+    'GET /v',
+    'GET /v',
+    'GET /v',
+]
+--- more_headers eval
+[
+    '',
+    "Host: vts-other\n",
+    "Host: vts-other\n",
+]
+--- response_body_like eval
+['OK', 'other', 'other']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Req-Counter)/s,
+    qr/\A(?!.*X-Req-Counter)/s,
+    qr/X-Req-Counter: 1\b/,
+]

--- a/util/coverage-badge.sh
+++ b/util/coverage-badge.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Publishes the line rate of a Cobertura report as a shields.io endpoint file
+# on the `badges` branch, which the badge in README.md reads.
+#
+# The branch holds that one file and nothing else. Each run replaces it with a
+# single commit and force pushes, so the branch does not grow and never shares
+# history with the code.
+#
+# usage: coverage-badge.sh <cobertura xml>
+#
+# expects GITHUB_TOKEN and GITHUB_REPOSITORY in the environment.
+
+set -eu
+
+xml=${1:?usage: $0 <cobertura xml>}
+branch=badges
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is not set}"
+
+rate=$(python3 - "$xml" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+
+print(round(float(root.get("line-rate")) * 100, 1))
+PY
+)
+
+# the thresholds the summary in the workflow reports against
+color=$(python3 - "$rate" <<'PY'
+import sys
+
+rate = float(sys.argv[1])
+
+print("red" if rate < 60 else "yellow" if rate < 80 else "brightgreen")
+PY
+)
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/coverage.json" <<EOF
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "$rate%",
+  "color": "$color"
+}
+EOF
+
+cd "$tmp"
+
+git init -q
+git checkout -q -b "$branch"
+git add coverage.json
+git -c user.name='github-actions[bot]' \
+    -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+    commit -q -m "coverage: $rate% of the lines"
+git push -q --force \
+    "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}" "$branch"
+
+echo "published $rate% ($color) to the $branch branch"


### PR DESCRIPTION
Three commits: a coverage job, a badge for the readme, and tests for the two
files the suite was not executing at all.

## What the tests were not reaching

Measured with a coverage build of nginx 1.30.4 over the whole of `t/`.

| | before | after | lines |
| --- | ---: | ---: | ---: |
| `dump.c` | **0.0%** | 82.0% | 183 |
| `variables.c` | **20.4%** | 90.9% | 44 |
| `module.c` | 67.6% | 72.8% | 438 |
| total | 76.6% | **81.6%** | 4057 |

**`dump.c` had nothing.** No test configured `vhost_traffic_status_dump`, so
neither the write nor the restore ever ran - and two recent changes live inside
them: the last-seen time a restored node is given (#375) and the filter count a
restored node is added to (#383, the sixth call site). `t/042` writes a dump,
has nginx start again and reads the counters back out of the display. Making
the restore a no-op fails TEST 2, 3 and 4.

The dump is kept outside the server root. Test::Nginx builds that directory
again for every block that changes the configuration, and a dump written under
it goes with it - which is the one thing the restore has to survive.

**`variables.c` was only reachable through lua.** The single test that read the
`$vts_*` variables went through `ngx_http_lua_module`, so any build without lua
left them untested, and they are meant to be read from an ordinary
configuration. `t/043` reads them with `add_header`: nothing before the zone
has a node, numbers after, and each server zone from its own node. Reading the
counter as 0 rather than from the node fails TEST 1 and TEST 3. The cache
variables are left out on purpose, being declared inside `#if (NGX_HTTP_CACHE)`.

## The job

A build with `--coverage`, the suite, and `gcovr` over the counters the workers
leave behind. gcovr writes Cobertura, which `CodeCoverageSummary` turns into a
table that goes into the run summary always, and onto the pull request as one
comment that later runs replace.

`-O0` goes with the instrumentation: at `-O` the arcs the counters hang off no
longer line up with the lines they were written for.

The build is nginx and this module alone, like the sanitizer job, so the lua
tests are left out the same way. promtool is installed because `t/022` checks
its output with it rather than skipping when it is missing.

Locally, over all of `t/`: **81.5% of 4045 lines, 59.4% of the branches, 160 of
167 functions.** The report and the summary can be reproduced by hand:

```sh
./auto/configure --add-module=/path/to/nginx-module-vts \
    --with-cc-opt="--coverage -O0" --with-ld-opt="--coverage"
make
TEST_NGINX_BINARY=objs/nginx prove -r /path/to/nginx-module-vts/t
gcovr --root /path/to/nginx-module-vts \
      --filter /path/to/nginx-module-vts/src/ \
      --print-summary objs/addon/src
```

## Three things worth a maintainer's opinion

**Workflow permissions.** The job asks for `contents: write` (the badge) and
`pull-requests: write` (the comment). If this repository's default workflow
permissions are read-only, both steps fail and the rest of the job still
reports into the run summary. Settings > Actions > General decides that.

**A `badges` branch.** The badge number has to live somewhere a browser can
read. The workflow force pushes a single file to a `badges` branch on every
master build - one commit, no shared history with the code, nothing to grow.
The alternative is Codecov or Coveralls, which read nicer but want an account
and a token this repository does not have. Say the word and I will swap it.

Until that branch exists - the first master build after this lands - the badge
reads as invalid.

**One more nginx build in CI.** The job is a fifth one and costs about the time
the sanitizer job does. It runs alongside the others rather than after them.

## A number is not a check

Coverage says a line ran, not that anything looked at what it did. Both new
files were checked the other way as well, by breaking the code they cover and
confirming the tests go red. The number is useful for finding the blank areas -
`dump.c` at 0% is how this started - and not for much else.

---

The run above reports **82% (2905 / 3557)** where the figures here say 4045
lines. The rate agrees; the denominator does not, because gcc and clang do not
count the same lines as executable. The measurements in this description were
taken with clang on darwin, CI takes them with gcc. Compare a run against
another run, not against a laptop.
