### PR TITLE
fix: write the peers of a group that the configuration does not name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ t/servroot
 front/dist
 front/node_modules
 t/vts.dump
+t/vts-unconfigured.dump

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -249,10 +249,12 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
                  * sources the display is written out of, so that the two
                  * cannot disagree about a peer.
                  *
-                 * A server line that resolves its name at run time is why the
-                 * peers come first: ngx_http_upstream_server() leaves a
-                 * placeholder holding the port and addrs[0].name is never set,
-                 * so there is nothing there to match on.
+                 * The two are exclusive rather than one falling back to the
+                 * other, and a server line that resolves its name at run time
+                 * is why: ngx_http_upstream_server() leaves a placeholder
+                 * holding the port and addrs[0].name is never set, so reading
+                 * the lines of a group that has a zone would answer for peers
+                 * that are not there and miss the ones that are.
                  */
 
 #if (NGX_HTTP_UPSTREAM_ZONE)

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -20,6 +20,10 @@ static ngx_int_t ngx_http_vhost_traffic_status_control_peer_lookup(
     ngx_http_upstream_server_t *usn);
 #endif
 
+static ngx_int_t ngx_http_vhost_traffic_status_control_server_lookup(
+    ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn);
+
 static void ngx_http_vhost_traffic_status_node_status_all(
     ngx_http_vhost_traffic_status_control_t *control);
 static void ngx_http_vhost_traffic_status_node_status_group(
@@ -136,6 +140,51 @@ ngx_http_vhost_traffic_status_control_peer_lookup(
 #endif
 
 
+/*
+ * The same, from the server lines of the group, which is what the display
+ * reads when the group has no zone to read instead.
+ */
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_control_server_lookup(
+    ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn)
+{
+    ngx_uint_t                   i, j;
+    ngx_http_upstream_server_t  *us;
+
+    us = uscf->servers->elts;
+
+    for (i = 0; i < uscf->servers->nelts; i++) {
+
+        /* a server gives one peer per address its name resolves to */
+
+        for (j = 0; j < us[i].naddrs; j++) {
+
+            if (us[i].addrs[j].name.len != name->len) {
+                continue;
+            }
+
+            if (ngx_strncmp(us[i].addrs[j].name.data, name->data, name->len)
+                != 0)
+            {
+                continue;
+            }
+
+            *usn = us[i];
+
+#if nginx_version > 1007001
+            usn->name = us[i].addrs[j].name;
+#endif
+
+            return NGX_OK;
+        }
+    }
+
+    return NGX_DECLINED;
+}
+
+
 void
 ngx_http_vhost_traffic_status_node_upstream_lookup(
     ngx_http_vhost_traffic_status_control_t *control,
@@ -143,8 +192,7 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
 {
     ngx_int_t                       rc;
     ngx_str_t                       key, usg, ush;
-    ngx_uint_t                      i, j, k;
-    ngx_http_upstream_server_t     *us;
+    ngx_uint_t                      i;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
 
@@ -192,71 +240,54 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
             continue;
         }
 
-        us = uscf->servers->elts;
-
         if (uscf->host.len == usg.len) {
             if (ngx_strncmp(uscf->host.data, usg.data, usg.len) == 0) {
 
-#if (NGX_HTTP_UPSTREAM_ZONE)
-
                 /*
-                 * A server line that resolves its name at run time leaves
-                 * nothing to match on: ngx_http_upstream_server() keeps a
-                 * placeholder holding the port, and addrs[0].name is never
-                 * set. The peers are made by the resolver and live in the
-                 * zone, which is where the display reads them since #322.
+                 * The peers of the group where it has a zone, backups
+                 * included, and the server lines where it has not - the two
+                 * sources the display is written out of, so that the two
+                 * cannot disagree about a peer.
                  *
-                 * With a zone those peers are the whole group, backups
-                 * included, so they answer on their own; the server lines are
-                 * all there is to read when there is no zone. This is the
-                 * same source the display reads, which is what keeps the two
-                 * from disagreeing about a peer.
+                 * A server line that resolves its name at run time is why the
+                 * peers come first: ngx_http_upstream_server() leaves a
+                 * placeholder holding the port and addrs[0].name is never set,
+                 * so there is nothing there to match on.
                  */
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
                 if (uscf->shm_zone != NULL) {
                     rc = ngx_http_vhost_traffic_status_control_peer_lookup(
                              uscf->peer.data, &ush, usn);
 
-                    if (rc == NGX_OK) {
-                        control->count++;
-                    }
-
-                    break;
+                } else {
+                    rc = ngx_http_vhost_traffic_status_control_server_lookup(
+                             uscf, &ush, usn);
                 }
-
+#else
+                rc = ngx_http_vhost_traffic_status_control_server_lookup(uscf,
+                         &ush, usn);
 #endif
 
-                for (j = 0; j < uscf->servers->nelts; j++) {
+                if (rc != NGX_OK) {
 
-                    /* a server gives one peer per address its name resolves to */
+                    /*
+                     * A peer the group does not hold: one a balancer_by_lua
+                     * block picked, one a re-resolve or a change of the
+                     * configuration took out. Its node is in the tree - the
+                     * caller looked it up before asking - and nothing here
+                     * knows anything else about it, so nothing else is
+                     * claimed. The display writes the same zeros.
+                     */
 
-                    for (k = 0; k < us[j].naddrs; k++) {
-                        if (us[j].addrs[k].name.len != ush.len) {
-                            continue;
-                        }
-
-                        if (ngx_strncmp(us[j].addrs[k].name.data, ush.data,
-                                        ush.len)
-                            != 0)
-                        {
-                            continue;
-                        }
-
-                        *usn = us[j];
+                    ngx_memzero(usn, sizeof(ngx_http_upstream_server_t));
 
 #if nginx_version > 1007001
-                        usn->name = us[j].addrs[k].name;
+                    usn->name = ush;
 #endif
-
-                        control->count++;
-
-                        break;
-                    }
-
-                    if (control->count) {
-                        break;
-                    }
                 }
+
+                control->count++;
 
                 break;
             }

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -16,20 +16,26 @@
 
 
 /*
- * The `resolve` parameter of the upstream server directive is available since
- * nginx 1.27.3 and needs an upstream zone. It came with the peers `resolve`
- * list and with NGX_HTTP_UPSTREAM_MODIFY, freenginx has neither of them.
+ * An upstream group is written out of its `server` lines and, where there is a
+ * zone, out of the peers the group holds. A node keyed under the group whose
+ * peer is in neither is never reached, and its statistics sit in the tree with
+ * nothing pointing at them. Three things put a peer there:
+ *
+ *   - a balancer_by_lua block picks an address of its own (#155)
+ *   - a re-resolve replaces the peers of a resolving group (#357)
+ *   - a server line is taken out of the configuration
+ *
+ * They are one case, and the peers of every group are collected in one pass
+ * over the tree: walking it once per group would cost as many passes as there
+ * are groups.
  */
-#if (NGX_HTTP_UPSTREAM_ZONE) && (nginx_version >= 1027003)                     \
-    && defined(NGX_HTTP_UPSTREAM_MODIFY) && !(defined freenginx)
-#define NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE  1
 
-/* an upstream group whose names are resolved at run time */
+/* an upstream group, and the peers of it that no longer exist */
 typedef struct {
     ngx_str_t     host;
     ngx_array_t  *names;  /* ngx_str_t, the peers the group has right now */
     ngx_array_t  *gone;   /* ngx_http_vhost_traffic_status_gone_peer_t */
-} ngx_http_vhost_traffic_status_resolve_t;
+} ngx_http_vhost_traffic_status_upstream_group_t;
 
 
 /* a node whose peer does not belong to its upstream group any more */
@@ -39,20 +45,19 @@ typedef struct {
 } ngx_http_vhost_traffic_status_gone_peer_t;
 
 
-static ngx_array_t *ngx_http_vhost_traffic_status_display_resolves(
+static ngx_array_t *ngx_http_vhost_traffic_status_display_upstream_groups(
     ngx_http_request_t *r);
 static ngx_array_t *ngx_http_vhost_traffic_status_display_upstream_peer_names(
-    ngx_http_request_t *r, ngx_http_upstream_rr_peers_t *peers);
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf);
 static ngx_uint_t ngx_http_vhost_traffic_status_display_upstream_peer_exists(
     ngx_array_t *names, ngx_str_t *name);
-static ngx_http_vhost_traffic_status_resolve_t *
-    ngx_http_vhost_traffic_status_display_resolve_lookup(ngx_array_t *resolves,
-    ngx_str_t *host);
+static ngx_http_vhost_traffic_status_upstream_group_t *
+    ngx_http_vhost_traffic_status_display_upstream_group_lookup(
+    ngx_array_t *groups, ngx_str_t *host);
 static void ngx_http_vhost_traffic_status_display_collect_gone_peers(
-    ngx_http_request_t *r, ngx_rbtree_node_t *node, ngx_array_t *resolves);
+    ngx_http_request_t *r, ngx_rbtree_node_t *node, ngx_array_t *groups);
 static u_char *ngx_http_vhost_traffic_status_display_set_upstream_gone(
     ngx_http_request_t *r, u_char *buf, ngx_array_t *gone);
-#endif
 
 u_char *
 ngx_http_vhost_traffic_status_display_set_main(ngx_http_request_t *r,
@@ -624,10 +629,8 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
     ngx_http_upstream_rr_peer_t           *peer;
     ngx_http_upstream_rr_peers_t          *peers;
 #endif
-#if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
-    ngx_array_t                             *resolves;
-    ngx_http_vhost_traffic_status_resolve_t *rs;
-#endif
+    ngx_array_t                           *groups;
+    ngx_http_vhost_traffic_status_upstream_group_t  *ug;
     ngx_http_upstream_srv_conf_t          *uscf, **uscfp;
     ngx_http_upstream_main_conf_t         *umcf;
     ngx_http_vhost_traffic_status_ctx_t   *ctx;
@@ -651,19 +654,12 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
      * Each key is now given the room it needs where it is built.
      */
 
-#if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
-    /*
-     * The nodes of the peers that a re-resolve took out of their upstream
-     * group are collected in one pass over the tree, walking it once per
-     * group would cost as many passes as there are groups.
-     */
-    resolves = ngx_http_vhost_traffic_status_display_resolves(r);
+    groups = ngx_http_vhost_traffic_status_display_upstream_groups(r);
 
-    if (resolves != NULL) {
+    if (groups != NULL) {
         ngx_http_vhost_traffic_status_display_collect_gone_peers(r,
-            ctx->rbtree->root, resolves);
+            ctx->rbtree->root, groups);
     }
-#endif
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
 
@@ -772,24 +768,6 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
                 ngx_http_upstream_rr_peers_unlock(peers);
             }
 
-#if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
-            /*
-             * The peers of an upstream that resolves the names at run time are
-             * replaced whenever the names are re-resolved. The nodes of the
-             * peers that are not part of the group any more still hold their
-             * statistics, add them after the current peers.
-             */
-            if (resolves != NULL) {
-                rs = ngx_http_vhost_traffic_status_display_resolve_lookup(
-                         resolves, &uscf->host);
-
-                if (rs != NULL && rs->gone != NULL) {
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_gone(
-                              r, buf, rs->gone);
-                }
-            }
-#endif
-
 not_supported:
 
 #endif
@@ -845,6 +823,22 @@ not_supported:
 #endif
                     }
 
+                }
+            }
+
+            /*
+             * The nodes of the peers the group holds no longer, after the ones
+             * it does. Written here rather than beside the peer lists so that
+             * a group with no zone is covered as well.
+             */
+
+            if (groups != NULL) {
+                ug = ngx_http_vhost_traffic_status_display_upstream_group_lookup(
+                         groups, &uscf->host);
+
+                if (ug != NULL && ug->gone != NULL) {
+                    buf = ngx_http_vhost_traffic_status_display_set_upstream_gone(
+                              r, buf, ug->gone);
                 }
             }
 
@@ -1078,16 +1072,14 @@ ngx_http_vhost_traffic_status_display_set(ngx_http_request_t *r,
     return buf;
 }
 
-#if (NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_RESOLVE)
-
 static int ngx_libc_cdecl
-ngx_http_vhost_traffic_status_display_resolve_cmp(const void *one,
+ngx_http_vhost_traffic_status_display_upstream_group_cmp(const void *one,
     const void *two)
 {
-    ngx_http_vhost_traffic_status_resolve_t  *first, *second;
+    ngx_http_vhost_traffic_status_upstream_group_t  *first, *second;
 
-    first = (ngx_http_vhost_traffic_status_resolve_t *) one;
-    second = (ngx_http_vhost_traffic_status_resolve_t *) two;
+    first = (ngx_http_vhost_traffic_status_upstream_group_t *) one;
+    second = (ngx_http_vhost_traffic_status_upstream_group_t *) two;
 
     return (int) ngx_memn2cmp(first->host.data, second->host.data,
                               first->host.len, second->host.len);
@@ -1101,132 +1093,151 @@ ngx_http_vhost_traffic_status_display_resolve_cmp(const void *one,
  * is the usual case.
  */
 static ngx_array_t *
-ngx_http_vhost_traffic_status_display_resolves(ngx_http_request_t *r)
+ngx_http_vhost_traffic_status_display_upstream_groups(ngx_http_request_t *r)
 {
-    ngx_uint_t                                i;
-    ngx_array_t                              *resolves;
-    ngx_http_upstream_rr_peers_t             *peers, *rpeers;
-    ngx_http_upstream_srv_conf_t             *uscf, **uscfp;
-    ngx_http_upstream_main_conf_t            *umcf;
-    ngx_http_vhost_traffic_status_resolve_t  *rs;
+    ngx_uint_t                                       i;
+    ngx_array_t                                     *groups;
+    ngx_http_upstream_srv_conf_t                    *uscf, **uscfp;
+    ngx_http_upstream_main_conf_t                   *umcf;
+    ngx_http_vhost_traffic_status_upstream_group_t  *ug;
 
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
     uscfp = umcf->upstreams.elts;
 
-    resolves = NULL;
+    groups = NULL;
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
 
         uscf = uscfp[i];
 
-        if (uscf->servers == NULL || uscf->port || uscf->shm_zone == NULL) {
+        /* an upstream that carries a port rather than servers is not a group */
+        if (uscf->servers == NULL || uscf->port) {
             continue;
         }
 
-        /*
-         * Either list can be the one that resolves: nginx builds a resolve
-         * list for the backup servers as well, so a group whose only
-         * resolving line is a backup has peers->resolve == NULL and a
-         * peers->next->resolve. Reading the primary list alone skips such a
-         * group, and what a replaced backup served stays in the tree with
-         * nothing pointing at it.
-         */
-
-        peers = uscf->peer.data;
-
-        for (rpeers = peers; rpeers; rpeers = rpeers->next) {
-            if (rpeers->resolve != NULL) {
-                break;
-            }
-        }
-
-        if (rpeers == NULL) {
-            continue;
-        }
-
-        if (resolves == NULL) {
-            resolves = ngx_array_create(r->pool, 2,
-                           sizeof(ngx_http_vhost_traffic_status_resolve_t));
-            if (resolves == NULL) {
+        if (groups == NULL) {
+            groups = ngx_array_create(r->pool, 2,
+                       sizeof(ngx_http_vhost_traffic_status_upstream_group_t));
+            if (groups == NULL) {
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                              "display_resolves::ngx_array_create() failed");
+                              "display_upstream_groups::ngx_array_create() failed");
                 return NULL;
             }
         }
 
-        rs = ngx_array_push(resolves);
-        if (rs == NULL) {
+        ug = ngx_array_push(groups);
+        if (ug == NULL) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "display_resolves::ngx_array_push() failed");
+                          "display_upstream_groups::ngx_array_push() failed");
             return NULL;
         }
 
-        rs->host = uscf->host;
-        rs->gone = NULL;
-        rs->names = ngx_http_vhost_traffic_status_display_upstream_peer_names(r,
-                        peers);
+        ug->host = uscf->host;
+        ug->gone = NULL;
+        ug->names = ngx_http_vhost_traffic_status_display_upstream_peer_names(r,
+                        uscf);
 
-        if (rs->names == NULL) {
+        if (ug->names == NULL) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "display_resolves::upstream_peer_names() failed");
+                          "display_upstream_groups::upstream_peer_names() failed");
             return NULL;
         }
     }
 
-    if (resolves != NULL && resolves->nelts > 1) {
-        ngx_qsort(resolves->elts, (size_t) resolves->nelts,
-                  sizeof(ngx_http_vhost_traffic_status_resolve_t),
-                  ngx_http_vhost_traffic_status_display_resolve_cmp);
+    if (groups != NULL && groups->nelts > 1) {
+        ngx_qsort(groups->elts, (size_t) groups->nelts,
+                  sizeof(ngx_http_vhost_traffic_status_upstream_group_t),
+                  ngx_http_vhost_traffic_status_display_upstream_group_cmp);
     }
 
-    return resolves;
+    return groups;
 }
 
 
 /*
- * Returns the names of the peers that currently belong to the upstream group,
- * backup peers included. The names are copied because the peers themselves may
- * be replaced by a re-resolve as soon as the lock is released.
+ * Returns the names of the peers that belong to the upstream group now, from
+ * the same place the group is written out of: the peer lists where there is a
+ * zone, backups included, and the server lines where there is not.
  */
 static ngx_array_t *
 ngx_http_vhost_traffic_status_display_upstream_peer_names(ngx_http_request_t *r,
-    ngx_http_upstream_rr_peers_t *peers)
+    ngx_http_upstream_srv_conf_t *uscf)
 {
-    u_char                       *p;
     ngx_str_t                    *name;
+    ngx_uint_t                    i, j;
     ngx_array_t                  *names;
+    ngx_http_upstream_server_t   *us;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    u_char                       *p;
     ngx_http_upstream_rr_peer_t  *peer;
+    ngx_http_upstream_rr_peers_t *peers;
+#endif
 
     names = ngx_array_create(r->pool, 4, sizeof(ngx_str_t));
     if (names == NULL) {
         return NULL;
     }
 
-    for ( /* void */ ; peers; peers = peers->next) {
+#if (NGX_HTTP_UPSTREAM_ZONE)
 
-        ngx_http_upstream_rr_peers_rlock(peers);
+    if (uscf->shm_zone != NULL) {
 
-        for (peer = peers->peer; peer; peer = peer->next) {
+        for (peers = uscf->peer.data; peers; peers = peers->next) {
+
+            ngx_http_upstream_rr_peers_rlock(peers);
+
+            for (peer = peers->peer; peer; peer = peer->next) {
+
+                name = ngx_array_push(names);
+                if (name == NULL) {
+                    ngx_http_upstream_rr_peers_unlock(peers);
+                    return NULL;
+                }
+
+                /*
+                 * The names are copied because the peers themselves may be
+                 * replaced by a re-resolve as soon as the lock is released.
+                 */
+
+                p = ngx_pnalloc(r->pool, peer->name.len);
+                if (p == NULL) {
+                    ngx_http_upstream_rr_peers_unlock(peers);
+                    return NULL;
+                }
+
+                ngx_memcpy(p, peer->name.data, peer->name.len);
+
+                name->data = p;
+                name->len = peer->name.len;
+            }
+
+            ngx_http_upstream_rr_peers_unlock(peers);
+        }
+
+        return names;
+    }
+
+#endif
+
+    /* the server lines, which is what is written when there is no zone */
+
+    us = uscf->servers->elts;
+
+    for (i = 0; i < uscf->servers->nelts; i++) {
+
+        /* a server gives one peer per address its name resolves to */
+
+        for (j = 0; j < us[i].naddrs; j++) {
 
             name = ngx_array_push(names);
             if (name == NULL) {
-                ngx_http_upstream_rr_peers_unlock(peers);
                 return NULL;
             }
 
-            p = ngx_pnalloc(r->pool, peer->name.len);
-            if (p == NULL) {
-                ngx_http_upstream_rr_peers_unlock(peers);
-                return NULL;
-            }
+            /* these are in the configuration pool and outlive the request */
 
-            ngx_memcpy(p, peer->name.data, peer->name.len);
-
-            name->data = p;
-            name->len = peer->name.len;
+            *name = us[i].addrs[j].name;
         }
-
-        ngx_http_upstream_rr_peers_unlock(peers);
     }
 
     return names;
@@ -1254,12 +1265,12 @@ ngx_http_vhost_traffic_status_display_upstream_peer_exists(ngx_array_t *names,
 }
 
 
-static ngx_http_vhost_traffic_status_resolve_t *
-ngx_http_vhost_traffic_status_display_resolve_lookup(ngx_array_t *resolves,
+static ngx_http_vhost_traffic_status_upstream_group_t *
+ngx_http_vhost_traffic_status_display_upstream_group_lookup(ngx_array_t *resolves,
     ngx_str_t *host)
 {
     ngx_int_t                                 rc, l, m, h;
-    ngx_http_vhost_traffic_status_resolve_t  *rs;
+    ngx_http_vhost_traffic_status_upstream_group_t  *rs;
 
     rs = resolves->elts;
 
@@ -1300,7 +1311,7 @@ ngx_http_vhost_traffic_status_display_collect_gone_peers(ngx_http_request_t *r,
     ngx_str_t                                  host, name;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_node_t      *vtsn;
-    ngx_http_vhost_traffic_status_resolve_t   *rs;
+    ngx_http_vhost_traffic_status_upstream_group_t   *rs;
     ngx_http_vhost_traffic_status_gone_peer_t *gone;
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
@@ -1328,7 +1339,7 @@ ngx_http_vhost_traffic_status_display_collect_gone_peers(ngx_http_request_t *r,
             name.data = p + 1;
             name.len = last - name.data;
 
-            rs = ngx_http_vhost_traffic_status_display_resolve_lookup(resolves,
+            rs = ngx_http_vhost_traffic_status_display_upstream_group_lookup(resolves,
                      &host);
 
             if (rs != NULL
@@ -1380,8 +1391,13 @@ ngx_http_vhost_traffic_status_display_set_upstream_gone(ngx_http_request_t *r,
 
         usn.name = peers[i].name;
 
-        /* the peer does not take any request any more */
-        usn.down = 1;
+        /*
+         * Everything else is left at zero. Whether such a peer is down is not
+         * knowable here: one a re-resolve took out cannot take a request, one
+         * a balancer picked is taking them right now, and the node says the
+         * same thing about both. `weight` and `max_fails` read 0 for the same
+         * reason, and false is what that means for a flag.
+         */
 
         buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf,
                   &usn, peers[i].node);
@@ -1389,7 +1405,5 @@ ngx_http_vhost_traffic_status_display_set_upstream_gone(ngx_http_request_t *r,
 
     return buf;
 }
-
-#endif
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -1087,10 +1087,13 @@ ngx_http_vhost_traffic_status_display_upstream_group_cmp(const void *one,
 
 
 /*
- * Returns the upstream groups that resolve their names at run time together
- * with the peers they have right now, sorted by host so that a node can be
- * matched to its group with a binary search. NULL when there is none, which
- * is the usual case.
+ * Returns every upstream group of the configuration together with the peers it
+ * holds right now, sorted by host so that a node can be matched to its group
+ * with a binary search.
+ *
+ * NULL when the configuration has no group at all, and also when an allocation
+ * on the way failed: the caller then writes the peers the groups do hold and
+ * loses only the ones they do not, which is what it wrote before this existed.
  */
 static ngx_array_t *
 ngx_http_vhost_traffic_status_display_upstream_groups(ngx_http_request_t *r)
@@ -1389,7 +1392,9 @@ ngx_http_vhost_traffic_status_display_set_upstream_gone(ngx_http_request_t *r,
 
         ngx_memzero(&usn, sizeof(ngx_http_upstream_server_t));
 
+#if nginx_version > 1007001
         usn.name = peers[i].name;
+#endif
 
         /*
          * Everything else is left at zero. Whether such a peer is down is not
@@ -1399,8 +1404,13 @@ ngx_http_vhost_traffic_status_display_set_upstream_gone(ngx_http_request_t *r,
          * reason, and false is what that means for a flag.
          */
 
+#if nginx_version > 1007001
         buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf,
                   &usn, peers[i].node);
+#else
+        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf,
+                  &usn, peers[i].node, &peers[i].name);
+#endif
     }
 
     return buf;

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -1269,25 +1269,25 @@ ngx_http_vhost_traffic_status_display_upstream_peer_exists(ngx_array_t *names,
 
 
 static ngx_http_vhost_traffic_status_upstream_group_t *
-ngx_http_vhost_traffic_status_display_upstream_group_lookup(ngx_array_t *resolves,
+ngx_http_vhost_traffic_status_display_upstream_group_lookup(ngx_array_t *groups,
     ngx_str_t *host)
 {
     ngx_int_t                                 rc, l, m, h;
-    ngx_http_vhost_traffic_status_upstream_group_t  *rs;
+    ngx_http_vhost_traffic_status_upstream_group_t  *ug;
 
-    rs = resolves->elts;
+    ug = groups->elts;
 
     l = 0;
-    h = (ngx_int_t) resolves->nelts - 1;
+    h = (ngx_int_t) groups->nelts - 1;
 
     while (l <= h) {
         m = l + (h - l) / 2;
 
-        rc = ngx_memn2cmp(host->data, rs[m].host.data,
-                          host->len, rs[m].host.len);
+        rc = ngx_memn2cmp(host->data, ug[m].host.data,
+                          host->len, ug[m].host.len);
 
         if (rc == 0) {
-            return &rs[m];
+            return &ug[m];
         }
 
         if (rc < 0) {
@@ -1308,13 +1308,13 @@ ngx_http_vhost_traffic_status_display_upstream_group_lookup(ngx_array_t *resolve
  */
 static void
 ngx_http_vhost_traffic_status_display_collect_gone_peers(ngx_http_request_t *r,
-    ngx_rbtree_node_t *node, ngx_array_t *resolves)
+    ngx_rbtree_node_t *node, ngx_array_t *groups)
 {
     u_char                                    *p, *last;
     ngx_str_t                                  host, name;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_node_t      *vtsn;
-    ngx_http_vhost_traffic_status_upstream_group_t   *rs;
+    ngx_http_vhost_traffic_status_upstream_group_t   *ug;
     ngx_http_vhost_traffic_status_gone_peer_t *gone;
 
     ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
@@ -1342,20 +1342,20 @@ ngx_http_vhost_traffic_status_display_collect_gone_peers(ngx_http_request_t *r,
             name.data = p + 1;
             name.len = last - name.data;
 
-            rs = ngx_http_vhost_traffic_status_display_upstream_group_lookup(resolves,
+            ug = ngx_http_vhost_traffic_status_display_upstream_group_lookup(groups,
                      &host);
 
-            if (rs != NULL
+            if (ug != NULL
                 && !ngx_http_vhost_traffic_status_display_upstream_peer_exists(
-                        rs->names, &name))
+                        ug->names, &name))
             {
-                if (rs->gone == NULL) {
-                    rs->gone = ngx_array_create(r->pool, 1,
+                if (ug->gone == NULL) {
+                    ug->gone = ngx_array_create(r->pool, 1,
                           sizeof(ngx_http_vhost_traffic_status_gone_peer_t));
                 }
 
-                if (rs->gone != NULL) {
-                    gone = ngx_array_push(rs->gone);
+                if (ug->gone != NULL) {
+                    gone = ngx_array_push(ug->gone);
 
                     if (gone != NULL) {
                         gone->name = name;
@@ -1372,9 +1372,9 @@ ngx_http_vhost_traffic_status_display_collect_gone_peers(ngx_http_request_t *r,
     }
 
     ngx_http_vhost_traffic_status_display_collect_gone_peers(r, node->left,
-        resolves);
+        groups);
     ngx_http_vhost_traffic_status_display_collect_gone_peers(r, node->right,
-        resolves);
+        groups);
 }
 
 

--- a/t/028.upstream_resolve.t
+++ b/t/028.upstream_resolve.t
@@ -124,6 +124,10 @@ __DATA__
 
 
 === TEST 2: a peer replaced by a re-resolve keeps its statistics
+# The peer that is gone is the one with weight 0: nothing is known about a peer
+# the group does not hold any more, and that is what the zeros say. It used to
+# be marked with down, which reads as a statement about a peer that a balancer
+# may in fact be using right now.
 --- http_config
     vhost_traffic_status_zone;
 
@@ -150,4 +154,4 @@ __DATA__
 --- request eval
 ['GET /up', 'GET /status/format/json']
 --- response_body_like eval
-['OK', qr/(?=.*"server":"127\.0\.0\.2:1984")(?=.*\{"server":"127\.0\.0\.1:1984","requestCounter":[1-9])(?=.*"127\.0\.0\.1:1984".*?"down":true)/s]
+['OK', qr/(?=.*"server":"127\.0\.0\.2:1984")(?=.*\{"server":"127\.0\.0\.1:1984","requestCounter":[1-9])(?=.*"127\.0\.0\.1:1984".*?"weight":0)/s]

--- a/t/041.upstream_backup_gone.t
+++ b/t/041.upstream_backup_gone.t
@@ -134,4 +134,4 @@ __DATA__
 --- request eval
 ['GET /up', 'GET /status/format/json']
 --- response_body_like eval
-['OK', qr/(?=.*"server":"127\.0\.0\.2:1984")(?=.*\{"server":"127\.0\.0\.1:1984","requestCounter":[1-9])(?=.*"127\.0\.0\.1:1984".*?"down":true)/s]
+['OK', qr/(?=.*"server":"127\.0\.0\.2:1984")(?=.*\{"server":"127\.0\.0\.1:1984","requestCounter":[1-9])(?=.*"127\.0\.0\.1:1984".*?"weight":0)/s]

--- a/t/044.upstream_unconfigured_peer.t
+++ b/t/044.upstream_unconfigured_peer.t
@@ -1,0 +1,218 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# An upstream group is written out of its `server` lines, so a node keyed under
+# the group whose peer is not one of them is never reached. The statistics are
+# in the tree and nothing prints them.
+#
+# Three things put a peer in that position, and they are the same case:
+#
+#   - a balancer_by_lua block picks an address of its own (#155)
+#   - a server line is taken out of the configuration
+#   - a re-resolve replaces the peers of a resolving group (#357, handled)
+#
+# The second one is what this file uses, because it needs neither lua nor a
+# resolver: the peers are measured, the dump keeps them across a restart, and
+# the configuration that comes back names only one of them.
+#
+# The dump is kept outside the server root, which Test::Nginx builds again for
+# every block that changes the configuration.
+
+use Test::Nginx::Socket;
+use File::Spec ();
+
+my $DumpFile = File::Spec->rel2abs('t/vts-unconfigured.dump');
+
+$ENV{TEST_NGINX_DUMP_FILE} = $DumpFile;
+
+unlink $DumpFile;
+
+add_cleanup_handler(sub { unlink $DumpFile });
+
+plan tests => repeat_each() * 14;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: both peers are measured
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "second";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1984;
+        server 127.0.0.1:1985;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_next_upstream off;
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- wait: 2
+--- request eval
+['GET /up', 'GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\A(OK|second)/,
+    qr/\A(OK|second)/,
+    qr/(?=.*"server":"127\.0\.0\.1:1984")(?=.*"server":"127\.0\.0\.1:1985")/s,
+]
+
+=== TEST 2: the one taken out of the configuration is still written
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "second";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /status/format/json']
+--- response_body_like eval
+[
+    qr/(?=.*"server":"127\.0\.0\.1:1984")(?=.*"server":"127\.0\.0\.1:1985")/s,
+]
+
+=== TEST 3: it keeps the counters it was measured with
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "second";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /up {
+        proxy_pass http://backend/ok;
+    }
+    location /keeps {
+        return 200 "keeps";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /status/format/json']
+--- response_body_like eval
+[
+    qr/"server":"127\.0\.0\.1:1985"(?:(?!"server":).)*"requestCounter":[1-9]/s,
+]
+
+=== TEST 4: what is not known about it is not claimed
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "second";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /not-claimed {
+        return 200 "not claimed";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /status/format/json']
+--- response_body_like eval
+[
+    qr/"server":"127\.0\.0\.1:1985"(?:(?!"server":).)*"weight":0(?:(?!"server":).)*"down":false/s,
+]
+
+=== TEST 5: the control interface reaches it too
+--- http_config
+    vhost_traffic_status_zone;
+    vhost_traffic_status_dump $TEST_NGINX_DUMP_FILE 1s;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "second";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+--- config
+    location /ok {
+        return 200 "OK";
+    }
+    location /reaches {
+        return 200 "reaches";
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+["GET /status/control?cmd=status&group=upstream\@group&zone=backend\@127.0.0.1%3A1985"]
+--- response_body_like eval
+[
+    qr/"server":"127\.0\.0\.1:1985".*"requestCounter":[1-9]/s,
+]


### PR DESCRIPTION
Towards #155.

## What is not written

An upstream group is written out of its `server` lines and, where it has a
zone, out of the peers the group holds. A node keyed under the group whose peer
is in neither is never reached, and its statistics sit in the tree with nothing
pointing at them.

Three things put a peer there, and they are one case:

- a `balancer_by_lua` block picks an address of its own (#155)
- a re-resolve replaces the peers of a resolving group (#357)
- a `server` line is taken out of the configuration

#322 built the machinery for the second and #357 wired it up, gated on the
group having a resolve list. **That gate is what this removes.**

The third one is what the test uses, because it needs neither lua nor a
resolver. Two peers measured, the dump carrying them across a restart, and a
configuration that comes back naming one of them:

| | master | with this |
| --- | --- | --- |
| `sharedZones.usedNode` | 3 | 3 |
| `upstreamZones` | `127.0.0.1:18901` only | both, the second with its counters |

Four requests' worth of statistics were in the tree and unreachable.

## What it does

The peers of every group are collected in one pass over the tree, and whatever
the group does not hold any more is written after the peers it does. The names
of the current peers are read from the same place the group is written out of -
the peer lists where there is a zone, backups included, the server lines where
there is not.

The control interface answers for such a peer too, for the reason it was made
to answer for a resolving one in #381: **the two must not disagree about the
same peer.** Its lookup takes the same two sources now, the server-line search
having moved into a function of its own beside the peer search added there.

## One behaviour changes

**A peer the group does not hold reports `down` false, where a re-resolved one
used to report true.**

Whether such a peer is down is not knowable here. One that a re-resolve took
out cannot take a request; one that a balancer picked is taking them right now;
the node says the same thing about both. `weight` and `max_fails` already read
0 for exactly that reason, and false is what that means for a flag.

`t/028` and `t/041` assert `weight` 0 in place of `down` true. It is the same
statement - this peer is not one the configuration describes - without reading
as a claim about whether it is taking traffic.

## Cost

The collection now runs for every group rather than for resolving ones only,
which is one pass over the tree on the display path. Measured there:

```
100 groups, 400 peers, 250 KB out     0.83 ms -> 0.87 ms
3001 nodes, 2.5 MB out               10.6 ms -> 11.0 ms
```

## Tests

`t/044.upstream_unconfigured_peer.t`, 14 assertions. TEST 1 holds what already
worked - both peers measured - and TEST 2 to 5 fail on master: the peer is
written, it keeps its counters, it claims nothing it does not know, and the
control interface reaches it.

The whole suite has no new failures, and the module builds with `-Werror` under
`--without-http_upstream_zone_module`, which CI does not cover.

## What #155 still wants

Not closing it. Two things in the report are not this:

- the `server 127.0.0.1:6666 down` placeholder such a configuration carries is
  still listed, with zeros, beside the peer the balancer used. Whether
  configured peers that never took a request should be written at all is a
  decision rather than a fix.
- `proxy_next_upstream` retries are still counted once, against the peer that
  answered, because `shm_add_upstream()` reads `u->state` - the last attempt.
  That is on the way in rather than the way out and is filed separately.
