### PR TITLE
fix: the free size figure builds on nginx before 1.11.7

### DIFF
--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -71,6 +71,10 @@ ngx_http_vhost_traffic_status_shm_info(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_shm_info_t *shm_info)
 {
     ngx_slab_pool_t                           *shpool;
+#if nginx_version < 1011007
+    ngx_uint_t                                 pfree;
+    ngx_slab_page_t                           *page;
+#endif
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
@@ -93,7 +97,29 @@ ngx_http_vhost_traffic_status_shm_info(ngx_http_request_t *r,
 
     if (vtscf->shm_zone != NULL) {
         shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
+
+#if nginx_version >= 1011007
         shm_info->free_size = shpool->pfree * ngx_pagesize;
+#else
+
+        /*
+         * pfree arrived with the slab statistics in 1.11.7. Before that the
+         * same number is the sum over the free page blocks, which is the list
+         * ngx_slab_alloc_pages() itself looks in for room. The caller holds
+         * the mutex of the zone, so the list does not move under the walk.
+         */
+
+        pfree = 0;
+
+        for (page = shpool->free.next;
+             page != &shpool->free;
+             page = page->next)
+        {
+            pfree += page->slab;
+        }
+
+        shm_info->free_size = pfree * ngx_pagesize;
+#endif
     }
 
     ngx_http_vhost_traffic_status_shm_info_node(r, shm_info, ctx->rbtree->root);


### PR DESCRIPTION
`ngx_slab_pool_t` gained `pfree` in **nginx 1.11.7**, with the slab statistics.
#361 read it without a guard:

```c
shm_info->free_size = shpool->pfree * ngx_pagesize;
```

so master does not compile against anything older, and neither does the
released **v0.2.7**, which carries that commit. The compatibility list in the
README starts at 1.4.x.

## Before 1.11.7

The same number is the sum over the free page blocks - the list
`ngx_slab_alloc_pages()` itself looks in for room:

```c
for (page = shpool->free.next; page != &shpool->free; page = page->next) {
    pfree += page->slab;
}
```

`ngx_slab_page_t` and `pool->free` are unchanged all the way back to 1.6.3, and
the caller already holds the mutex of the zone, so the list does not move under
the walk.

## Checked both ways

**That it builds.** Compiling the module's sources against the old trees, with
`--with-http_stub_status_module` so that `ngx_stat_*` is declared:

| | master | with this |
| --- | --- | --- |
| nginx 1.6.3 | ✗ | ✔ |
| nginx 1.10.3 | ✗ | ✔ |
| nginx 1.11.6 | ✗ | ✔ |
| nginx 1.11.7 | ✔ | ✔ |

**That the number is the same one.** Forcing the fallback on 1.30.4, where both
are available, against the same load:

```
nodes         0       51      101
pfree    1015808   802816   589824
fallback 1015808   802816   589824
```

That matters more than it looks: reading 0 there would show as a zone with no
room left, which is the state #361 added the figure to make visible.

`t/033.shm_free_size.t` passes, and the suite has no new failures.

## Not in this

`ngx_stat_accepted` and the rest are read without a guard too, in
`display_json.c` and `display_prometheus.c`. That is a different thing: they
have existed since nginx 0.1.18 and are declared only when
`--with-http_stub_status_module` is configured, so it is a build option this
module has always required rather than a version it stopped supporting. It has
been that way since the first commit. Worth writing down in the README, not
worth changing here.
