### PR TITLE
ci: check the lock discipline while the tests run, not by reading the sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,13 @@ jobs:
           # taking the mutex. Put that back, and the check has to say so - a
           # detector that has never detected anything is not evidence.
           cp src/ngx_http_vhost_traffic_status_set.c /tmp/set.c.orig
-          sed -i '/ngx_shmtx_lock(&shpool->mutex);/d;/ngx_shmtx_unlock(&shpool->mutex);/d' \
+          # the lock is replaced rather than deleted: dropping both lines
+          # leaves shpool set and never read, and -Werror stops the build
+          # before the check gets a chance to say anything
+          sed -i 's|ngx_shmtx_lock(&shpool->mutex);|(void) shpool;|; \
+                  s|ngx_shmtx_unlock(&shpool->mutex);||' \
               src/ngx_http_vhost_traffic_status_set.c
+          grep -q '(void) shpool;' src/ngx_http_vhost_traffic_status_set.c
           ( cd ../nginx && make -j$(nproc) > /dev/null && sudo make install > /dev/null )
           sudo rm -f /tmp/vts-lockcheck.log
           sudo PATH=/usr/local/nginx-lc/sbin:$PATH prove t/021.set_by_filter.t > /dev/null 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,10 +366,13 @@ jobs:
           # the lock is replaced rather than deleted: dropping both lines
           # leaves shpool set and never read, and -Werror stops the build
           # before the check gets a chance to say anything
-          sed -i 's|ngx_shmtx_lock(&shpool->mutex);|(void) shpool;|; \
-                  s|ngx_shmtx_unlock(&shpool->mutex);||' \
-              src/ngx_http_vhost_traffic_status_set.c
+          # one call each: a backslash before a newline inside single quotes
+          # is not a continuation, it is a backslash, and sed reads it as the
+          # start of an address it never finds the end of
+          sed -i 's|ngx_shmtx_lock(&shpool->mutex);|(void) shpool;|' src/ngx_http_vhost_traffic_status_set.c
+          sed -i 's|ngx_shmtx_unlock(&shpool->mutex);||' src/ngx_http_vhost_traffic_status_set.c
           grep -q '(void) shpool;' src/ngx_http_vhost_traffic_status_set.c
+          ! grep -q 'ngx_shmtx_' src/ngx_http_vhost_traffic_status_set.c
           ( cd ../nginx && make -j$(nproc) > /dev/null && sudo make install > /dev/null )
           sudo rm -f /tmp/vts-lockcheck.log
           sudo PATH=/usr/local/nginx-lc/sbin:$PATH prove t/021.set_by_filter.t > /dev/null 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,89 @@ jobs:
         working-directory: nginx-module-vts
         run: sudo tail -n 100 t/servroot/logs/error.log || true
 
+  lockcheck:
+    name: 'lock discipline'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: nginx-module-vts
+      - name: 'checkout nginx'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: nginx/nginx
+          path: nginx
+          ref: '017cf98dcce217946572a896f0992370475e189f'
+      - name: 'prepare cpanm'
+        run: |
+          sudo apt install -y cpanminus
+          sudo cpanm --notest Test::Nginx::Socket > build.log 2>&1 || (cat build.log && exit 1)
+      - name: 'prepare promtool'
+        env:
+          # pinned, for the reason given in the job above
+          PROMETHEUS_VERSION: '3.13.2'
+        run: |
+          curl -fsSL -o prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar xzf prometheus.tar.gz
+          sudo mv prometheus-*/promtool /usr/local/bin
+          promtool --version
+      - name: 'build nginx with the lock check linked in'
+        working-directory: nginx
+        run: |
+          cc -c -o "$GITHUB_WORKSPACE/lockcheck.o" \
+             "$GITHUB_WORKSPACE/nginx-module-vts/util/lockcheck.c"
+          ./auto/configure \
+            --prefix=/usr/local/nginx-lc \
+            --add-module="$GITHUB_WORKSPACE/nginx-module-vts" \
+            --with-ld-opt="-Wl,--wrap=ngx_shmtx_lock \
+                           -Wl,--wrap=ngx_shmtx_unlock \
+                           -Wl,--wrap=ngx_http_vhost_traffic_status_find_node \
+                           $GITHUB_WORKSPACE/lockcheck.o"
+          make -j$(nproc)
+          sudo make install
+          # the wrapper is only useful if the linker actually redirected
+          nm /usr/local/nginx-lc/sbin/nginx | grep -q '__wrap_ngx_http_vhost_traffic_status_find_node'
+      - name: 'prove the check can fail'
+        working-directory: nginx-module-vts
+        run: |
+          # #355 is what this is for: set_by_filter walked the tree without
+          # taking the mutex. Put that back, and the check has to say so - a
+          # detector that has never detected anything is not evidence.
+          cp src/ngx_http_vhost_traffic_status_set.c /tmp/set.c.orig
+          sed -i '/ngx_shmtx_lock(&shpool->mutex);/d;/ngx_shmtx_unlock(&shpool->mutex);/d' \
+              src/ngx_http_vhost_traffic_status_set.c
+          ( cd ../nginx && make -j$(nproc) > /dev/null && sudo make install > /dev/null )
+          sudo rm -f /tmp/vts-lockcheck.log
+          sudo PATH=/usr/local/nginx-lc/sbin:$PATH prove t/021.set_by_filter.t > /dev/null 2>&1 || true
+          if [ ! -s /tmp/vts-lockcheck.log ]; then
+            echo '::error::the lock check did not report the violation it was given'
+            exit 1
+          fi
+          echo "detected $(wc -l < /tmp/vts-lockcheck.log) violation(s), as it should"
+          cp /tmp/set.c.orig src/ngx_http_vhost_traffic_status_set.c
+          ( cd ../nginx && make -j$(nproc) > /dev/null && sudo make install > /dev/null )
+      - name: 'run the suite under it'
+        working-directory: nginx-module-vts
+        run: |
+          sudo rm -f /tmp/vts-lockcheck.log
+          # the lua tests need modules that are not part of this build
+          sudo PATH=/usr/local/nginx-lc/sbin:$PATH prove $(ls t/*.t | grep -v '_by_lua')
+      - name: 'check the report'
+        if: always()
+        run: |
+          if [ -s /tmp/vts-lockcheck.log ]; then
+            echo '::error::the tree was walked without the mutex'
+            sort /tmp/vts-lockcheck.log | uniq -c
+            exit 1
+          fi
+          echo 'no violations'
+      - name: 'dump nginx error log'
+        if: failure()
+        working-directory: nginx-module-vts
+        run: sudo tail -n 100 t/servroot/logs/error.log || true
+
   build-variants:
     name: 'build (${{ matrix.variant.name }})'
     runs-on: ubuntu-24.04

--- a/util/lockcheck.c
+++ b/util/lockcheck.c
@@ -36,10 +36,18 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * Weak, because configure links a trivial program with the ld options it is
+ * given to see whether they work, and this object goes with them. The linker
+ * defines __real_* only where --wrap has something to wrap, so in that test
+ * link they resolve to nothing and the test passes. In the real one they are
+ * the functions the calls were going to.
+ */
+
 extern void *__real_ngx_http_vhost_traffic_status_find_node(void *r, void *key,
-    unsigned type, unsigned flag);
-extern void  __real_ngx_shmtx_lock(void *mtx);
-extern void  __real_ngx_shmtx_unlock(void *mtx);
+    unsigned type, unsigned flag) __attribute__((weak));
+extern void  __real_ngx_shmtx_lock(void *mtx) __attribute__((weak));
+extern void  __real_ngx_shmtx_unlock(void *mtx) __attribute__((weak));
 
 /* one per process: the workers do not share it, and neither do they need to */
 static unsigned  vts_lc_depth;
@@ -73,6 +81,10 @@ vts_lc_report(const char *what)
 void
 __wrap_ngx_shmtx_lock(void *mtx)
 {
+    if (__real_ngx_shmtx_lock == NULL) {
+        return;
+    }
+
     __real_ngx_shmtx_lock(mtx);
 
     vts_lc_depth++;
@@ -82,6 +94,10 @@ __wrap_ngx_shmtx_lock(void *mtx)
 void
 __wrap_ngx_shmtx_unlock(void *mtx)
 {
+    if (__real_ngx_shmtx_unlock == NULL) {
+        return;
+    }
+
     if (vts_lc_depth) {
         vts_lc_depth--;
     }
@@ -94,6 +110,10 @@ void *
 __wrap_ngx_http_vhost_traffic_status_find_node(void *r, void *key,
     unsigned type, unsigned flag)
 {
+    if (__real_ngx_http_vhost_traffic_status_find_node == NULL) {
+        return NULL;
+    }
+
     if (vts_lc_depth == 0) {
         vts_lc_report("find_node was entered with no mutex held");
     }

--- a/util/lockcheck.c
+++ b/util/lockcheck.c
@@ -1,0 +1,102 @@
+/*
+ * Checks, while the tests run, that the tree is never walked without the
+ * mutex of the zone being held.
+ *
+ * No source file of the module knows about this. It is linked in with
+ * -Wl,--wrap, which sends the calls that cross a translation unit to the
+ * __wrap_ names here and leaves __real_ as the function that would have been
+ * called. That is why it can be a build of its own rather than instrumentation
+ * the module has to carry.
+ *
+ * What it can and cannot see:
+ *
+ *   - the depth counts every ngx_shmtx_lock() the process takes, this module's
+ *     or nginx's own, so a lock held elsewhere can hide a violation. It cannot
+ *     invent one, which is the direction that matters for a check that fails a
+ *     build.
+ *   - a call within the translation unit that defines the function is resolved
+ *     without going through the symbol, so it is not wrapped. Every caller of
+ *     find_node() is in another file.
+ *
+ * usage:
+ *
+ *   cc -c -o lockcheck.o util/lockcheck.c
+ *   ./configure --add-module=... \
+ *       --with-ld-opt="-Wl,--wrap=ngx_shmtx_lock \
+ *                      -Wl,--wrap=ngx_shmtx_unlock \
+ *                      -Wl,--wrap=ngx_http_vhost_traffic_status_find_node \
+ *                      /abs/path/lockcheck.o"
+ *
+ * Every violation appends a line to $VTS_LOCKCHECK_LOG, or to
+ * /tmp/vts-lockcheck.log. An empty or absent file is a clean run.
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void *__real_ngx_http_vhost_traffic_status_find_node(void *r, void *key,
+    unsigned type, unsigned flag);
+extern void  __real_ngx_shmtx_lock(void *mtx);
+extern void  __real_ngx_shmtx_unlock(void *mtx);
+
+/* one per process: the workers do not share it, and neither do they need to */
+static unsigned  vts_lc_depth;
+
+
+static void
+vts_lc_report(const char *what)
+{
+    int          fd;
+    const char  *path;
+
+    path = getenv("VTS_LOCKCHECK_LOG");
+
+    if (path == NULL) {
+        path = "/tmp/vts-lockcheck.log";
+    }
+
+    fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+
+    if (fd < 0) {
+        return;
+    }
+
+    (void) write(fd, what, strlen(what));
+    (void) write(fd, "\n", 1);
+
+    close(fd);
+}
+
+
+void
+__wrap_ngx_shmtx_lock(void *mtx)
+{
+    __real_ngx_shmtx_lock(mtx);
+
+    vts_lc_depth++;
+}
+
+
+void
+__wrap_ngx_shmtx_unlock(void *mtx)
+{
+    if (vts_lc_depth) {
+        vts_lc_depth--;
+    }
+
+    __real_ngx_shmtx_unlock(mtx);
+}
+
+
+void *
+__wrap_ngx_http_vhost_traffic_status_find_node(void *r, void *key,
+    unsigned type, unsigned flag)
+{
+    if (vts_lc_depth == 0) {
+        vts_lc_report("find_node was entered with no mutex held");
+    }
+
+    return __real_ngx_http_vhost_traffic_status_find_node(r, key, type, flag);
+}


### PR DESCRIPTION
Replaces #365, which is closed.

## Why not the static one

#365 read `src/*.c` and reported two shapes: a tree lookup with no
`ngx_shmtx_lock()` above it in the same function, and a `return` that leaves one
held. It catches #355 and costs nothing. What it cannot say is whether the lock
was **held when the tree was touched**, because that depends on the caller - so
it carries a hand-kept list of functions whose callers hold it. That list is
right today and rots quietly.

The tools that answer the question directly do not apply here. The workers are
processes rather than threads, so ThreadSanitizer and Helgrind have nothing to
look at; the nodes come from `ngx_slab_alloc` rather than malloc, so
AddressSanitizer cannot see them.

## What does apply

The linker. `-Wl,--wrap` sends the calls that cross a translation unit to a
wrapper of our own, so both the mutex and `find_node()` can be watched **without
a single line inside the module**. `util/lockcheck.c` counts the locks the
process holds and writes a line whenever `find_node()` is entered at depth zero.

Every caller of `find_node()` is in another file - `limit.c`, `shm.c`,
`variables.c`, `set.c` - so every one is covered. Those are exactly the request
paths that have to hold the mutex.

An earlier prototype of this idea needed 141 lines inside the module, which is
why it was set aside. This needs none.

## The job proves the check before trusting it

It puts #355 back - the two `ngx_shmtx_lock` lines `set_by_filter` was missing -
rebuilds, runs `t/021`, and **fails if nothing was reported**. A detector that
has never detected anything is not evidence. Then it restores the file and runs
the suite, which has to come out clean.

## What it can miss

The depth counts every `ngx_shmtx_lock()` the process takes, this module's or
nginx's own, so a lock held elsewhere could hide a violation. It cannot invent
one, which is the direction that matters for a check that fails a build.

A call within the translation unit that defines the function is resolved without
going through the symbol and is not wrapped; `node.c` does not call
`find_node()` itself.

## Note on how this was tested

`--wrap` is GNU ld, and the machine this was written on is macOS, whose linker
does not have it. The job is written to validate itself for that reason: if the
wrapper is not linked in, the `nm` check fails; if the check cannot detect
#355, the job fails. This PR is where it runs for the first time.
