### PR TITLE
fix: count every upstream attempt, not only the last one

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Traffic calculation as follows:
 * UpstreamZones
   * in += requested_bytes via the ServerZones
   * out += sent_bytes via the ServerZones
+  * an attempt that `proxy_next_upstream` passed on adds neither, having served no client request. It is still counted in `requestCounter` and in `responses`, and its own time in `responseMsecCounter`.
 * cacheZones
   * in += requested_bytes via the ServerZones
   * out += sent_bytes via the ServerZones
@@ -760,14 +761,14 @@ The following status information is provided in the JSON format:
   * server
     * An address of the server.
   * requestCounter
-    * The total number of client connections forwarded to this server.
+    * The total number of client connections forwarded to this server. A request that `proxy_next_upstream` passes on is counted against every server it was tried on, so the counters of a group add up to attempts rather than to client requests. This is the same thing `$upstream_addr` reports, which lists one address per attempt.
   * inBytes
-    * The total number of bytes received from this server.
+    * The total number of bytes received from this server. An attempt that was passed on to another server adds nothing here: these are the bytes of the client request, and such an attempt served none.
   * outBytes
-    * The total number of bytes sent to this server.
+    * The total number of bytes sent to this server. An attempt that was passed on adds nothing, for the same reason as `inBytes`.
   * responses
     * 1xx, 2xx, 3xx, 4xx, 5xx
-      * The number of responses with status codes 1xx, 2xx, 3xx, 4xx, and 5xx.
+      * The number of responses with status codes 1xx, 2xx, 3xx, 4xx, and 5xx. For an attempt that was passed on to another server this is the status of that attempt - the value `$upstream_status` logs for it, which is 502 where the connection was refused and 504 where it timed out. For the attempt that answered the client it is the status the client was sent.
   * requestMsecCounter
     * The number of accumulated request processing time including upstream in milliseconds.
   * requestMsec
@@ -783,7 +784,7 @@ The following status information is provided in the JSON format:
     * counters
       * The cumulative values for the reason that each bucket value is greater than or equal to the request processing time including upstream.
   * responseMsecCounter
-    * The number of accumulated only upstream response processing time in milliseconds.
+    * The number of accumulated only upstream response processing time in milliseconds. Each attempt contributes its own time to the server it was made on. Earlier versions gave the sum over every attempt of a request to whichever server answered it, so that server was charged for the time spent failing on the ones before it.
   * responseMsec
     * The average of only upstream response processing times in milliseconds.
   * responseMsecs

--- a/src/ngx_http_vhost_traffic_status_module.c
+++ b/src/ngx_http_vhost_traffic_status_module.c
@@ -366,33 +366,35 @@ ngx_http_vhost_traffic_status_request_time(ngx_http_request_t *r)
 
 
 ngx_msec_int_t
-ngx_http_vhost_traffic_status_upstream_response_time(ngx_http_request_t *r)
+ngx_http_vhost_traffic_status_upstream_state_response_time(
+    ngx_http_upstream_state_t *state)
 {
-    ngx_uint_t                  i;
-    ngx_msec_int_t              ms;
-    ngx_http_upstream_state_t  *state;
+    ngx_msec_int_t  ms;
 
-    state = r->upstream_states->elts;
+    /*
+     * A state with no status never got a response, and there is no attempt at
+     * all where the caller had nothing to give.
+     */
 
-    i = 0;
-    ms = 0;
-    for ( ;; ) {
-        if (state[i].status) {
+    if (state == NULL || state->status == 0) {
+        return 0;
+    }
 
 #if !defined(nginx_version) || nginx_version < 1009001
-            ms += (ngx_msec_int_t)
-                  (state[i].response_sec * 1000 + state[i].response_msec);
+    ms = (ngx_msec_int_t) (state->response_sec * 1000 + state->response_msec);
 #else
-            ms += state[i].response_time;
+    ms = (ngx_msec_int_t) state->response_time;
 #endif
 
-        }
-        if (++i == r->upstream_states->nelts) {
-            break;
-        }
-    }
     return ngx_max(ms, 0);
 }
+
+
+/*
+ * The sum over every attempt of a request used to be what an upstream node
+ * recorded, given to whichever peer answered. Each attempt now carries its
+ * own time to its own peer, so nothing wants the sum any more.
+ */
 
 
 static void

--- a/src/ngx_http_vhost_traffic_status_module.h
+++ b/src/ngx_http_vhost_traffic_status_module.h
@@ -404,7 +404,8 @@ uint32_t ngx_http_vhost_traffic_status_filter_max_node_signature(
 
 ngx_msec_t ngx_http_vhost_traffic_status_current_msec(void);
 ngx_msec_int_t ngx_http_vhost_traffic_status_request_time(ngx_http_request_t *r);
-ngx_msec_int_t ngx_http_vhost_traffic_status_upstream_response_time(ngx_http_request_t *r);
+ngx_msec_int_t ngx_http_vhost_traffic_status_upstream_state_response_time(
+    ngx_http_upstream_state_t *state);
 
 extern ngx_module_t ngx_http_vhost_traffic_status_module;
 

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -532,6 +532,23 @@ ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
 
     vtsn->stat_request_counter++;
 
+    if (state != NULL && (status < 100 || status >= 600)) {
+
+        /*
+         * An attempt carries no status of its own where it produced no
+         * response, and nginx leaves that 0. add_rc() puts anything below 200
+         * in the 1xx bucket, so it must not be handed one - the attempt would
+         * be reported as an informational response. The two other places that
+         * read this status already say the same thing: shm_add_node() takes no
+         * status code slot outside 100..599, and the response time helper
+         * gives 0 for a state with no status.
+         *
+         * It was still an attempt on this peer, so the counter above stands.
+         */
+
+        return;
+    }
+
     ngx_http_vhost_traffic_status_add_rc(status, vtsn);
 
     if (status_code_slot != -1 && vtsn->stat_status_code_counter != NULL ) {

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -447,7 +447,8 @@ ngx_http_vhost_traffic_status_node_zero(ngx_http_vhost_traffic_status_node_t *vt
 */
 void
 ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot)
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state)
 {
     ngx_msec_int_t  ms;
 
@@ -467,7 +468,7 @@ ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
     /* set serverZone */
     ms = ngx_http_vhost_traffic_status_request_time(r);
 
-    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot);
+    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot, state);
 }
 
 
@@ -477,7 +478,8 @@ ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
 */
 void
 ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot)
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state)
 {
     ngx_msec_int_t                             ms;
     ngx_http_vhost_traffic_status_node_oc_t    ovtsn;
@@ -489,7 +491,7 @@ ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
 
     vtsn->ignore_status = vtscf->ignore_status;
     ms = ngx_http_vhost_traffic_status_request_time(r);
-    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot);
+    ngx_http_vhost_traffic_status_node_update(r, vtsn, ms, status_code_slot, state);
 
     /*
      * stat_request_time is not kept up to date here: averaging the queue on
@@ -503,9 +505,17 @@ ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
 
 void
 ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot)
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state)
 {
-    ngx_uint_t status = r->headers_out.status;
+    /*
+     * state is the attempt this call is counting, and it is set only where
+     * proxy_next_upstream passed that attempt on to another peer. Everything
+     * else - every server, filter and cache zone, and the attempt that did
+     * serve the client - counts the client request and leaves it NULL.
+     */
+
+    ngx_uint_t status = (state != NULL) ? state->status : r->headers_out.status;
 
     /*
      * Before the check below: a request whose status is not counted was
@@ -520,14 +530,28 @@ ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
     }
 
     vtsn->stat_request_counter++;
-    vtsn->stat_in_bytes += (ngx_atomic_uint_t) r->request_length;
-    vtsn->stat_out_bytes += (ngx_atomic_uint_t) r->connection->sent;
 
     ngx_http_vhost_traffic_status_add_rc(status, vtsn);
 
     if (status_code_slot != -1 && vtsn->stat_status_code_counter != NULL ) {
         vtsn->stat_status_code_counter[status_code_slot]++;
     }
+
+    if (state != NULL) {
+
+        /*
+         * The rest of this describes the client request: the bytes either
+         * way, how long it took, what the cache did with it. An attempt that
+         * was passed on served no client, so it has none of them to add. Its
+         * own response time goes to the upstream queue in
+         * ngx_http_vhost_traffic_status_shm_add_node_upstream().
+         */
+
+        return;
+    }
+
+    vtsn->stat_in_bytes += (ngx_atomic_uint_t) r->request_length;
+    vtsn->stat_out_bytes += (ngx_atomic_uint_t) r->connection->sent;
 
     vtsn->stat_request_time_counter += (ngx_atomic_uint_t) ms;
 

--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -518,9 +518,10 @@ ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
     ngx_uint_t status = (state != NULL) ? state->status : r->headers_out.status;
 
     /*
-     * Before the check below: a request whose status is not counted was
-     * served all the same, and what tells the node apart from an abandoned
-     * one is that it was reached, not that it was counted.
+     * Before the check below: a status that is not counted still leaves the
+     * node reached - the client request was served, or the attempt on this
+     * peer was made - and being reached is what tells it apart from one
+     * nothing has used in a long time. Being counted is not.
      */
 
     vtsn->stat_last_seen = ngx_http_vhost_traffic_status_current_msec();

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -158,12 +158,20 @@ ngx_rbtree_node_t *ngx_http_vhost_traffic_status_node_lookup(
     ngx_rbtree_t *rbtree, ngx_str_t *key, uint32_t hash);
 void ngx_http_vhost_traffic_status_node_zero(
     ngx_http_vhost_traffic_status_node_t *vtsn);
+/*
+ * state is the upstream attempt being counted, and it is set only for an
+ * attempt that proxy_next_upstream passed on to another peer. NULL counts the
+ * client request, which is what every other caller wants.
+ */
 void ngx_http_vhost_traffic_status_node_init(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot);
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state);
 void ngx_http_vhost_traffic_status_node_set(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot);
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state);
 void ngx_http_vhost_traffic_status_node_update(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot);
+    ngx_http_vhost_traffic_status_node_t *vtsn, ngx_msec_int_t ms, ngx_int_t status_code_slot,
+    ngx_http_upstream_state_t *state);
 
 void ngx_http_vhost_traffic_status_node_time_queue_zero(
     ngx_http_vhost_traffic_status_node_time_queue_t *q);

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -164,7 +164,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     status_code_slot = 0;
     if (ctx->measure_all_status_codes) {
         if (status >= 100 && status < 600) {
-            // slot 0 is reserved to other status codes <100 and >600
+            // slot 0 is reserved to other status codes <100 and >=600
             status_code_slot = status - 99;
         }
     } else if (ctx->measure_status_codes != NULL) {

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -640,6 +640,24 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
 
 found:
 
+    /*
+     * This reads as though a last attempt with no peer would throw away the
+     * attempts before it, which have one. It cannot: nginx leaves peer unset
+     * on one path only.
+     *
+     *   ngx_http_upstream_connect()
+     *       rc = ngx_event_connect_peer(&u->peer);
+     *       if (rc == NGX_ERROR) { finalize(500); return; }   <- unset here
+     *       u->state->peer = u->peer.name;                    <- every other rc
+     *
+     * NGX_BUSY, the "no live upstreams" case one would expect to leave it
+     * unset, does not: ngx_http_upstream_get_round_robin_peer() assigns
+     * pc->name = peers->name, the name of the group, before returning it.
+     * What is left is ngx_event_connect_peer() failing outright - a socket
+     * that could not be made, a connection that could not be taken - which no
+     * configuration can ask for.
+     */
+
     if (u->state->peer == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "shm_add_upstream::peer failed");
@@ -664,10 +682,7 @@ found:
 
         if (state->peer == NULL) {
 
-            /*
-             * An attempt that never reached a peer - no address was left to
-             * try, or the resolver had nothing. There is nothing to key on.
-             */
+            /* nothing to key on. See the note above: no traffic gets here */
 
             continue;
         }

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -591,7 +591,7 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
     unsigned                        type;
     ngx_int_t                       rc;
     ngx_str_t                      *host, key, dst;
-    ngx_uint_t                      i;
+    ngx_uint_t                      i, n;
     ngx_http_upstream_t            *u;
     ngx_http_upstream_state_t      *state, *states;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
@@ -641,21 +641,17 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
 found:
 
     /*
-     * This reads as though a last attempt with no peer would throw away the
-     * attempts before it, which have one. It cannot: nginx leaves peer unset
-     * on one path only.
+     * An attempt that connected always has this. ngx_http_upstream_connect()
+     * assigns it for every return of ngx_event_connect_peer() except
+     * NGX_ERROR, which finalizes the request at once - NGX_BUSY, the "no live
+     * upstreams" case one would expect to leave it unset, does not, since
+     * ngx_http_upstream_get_round_robin_peer() assigns pc->name = peers->name
+     * before returning it.
      *
-     *   ngx_http_upstream_connect()
-     *       rc = ngx_event_connect_peer(&u->peer);
-     *       if (rc == NGX_ERROR) { finalize(500); return; }   <- unset here
-     *       u->state->peer = u->peer.name;                    <- every other rc
-     *
-     * NGX_BUSY, the "no live upstreams" case one would expect to leave it
-     * unset, does not: ngx_http_upstream_get_round_robin_peer() assigns
-     * pc->name = peers->name, the name of the group, before returning it.
-     * What is left is ngx_event_connect_peer() failing outright - a socket
-     * that could not be made, a connection that could not be taken - which no
-     * configuration can ask for.
+     * What has none is the zeroed state that ngx_http_upstream_init_request()
+     * pushes between two rounds - see the walk below. u->state is that one
+     * where a second round was set up and never connected, and there is
+     * nothing to record for it.
      */
 
     if (u->state->peer == NULL) {
@@ -674,15 +670,38 @@ found:
      * client requests, which is what $upstream_addr has always reported.
      */
 
-    states = r->upstream_states->elts;
+    /*
+     * Only the attempts of the upstream this request ended in.
+     *
+     * r->upstream_states is request-wide rather than per-upstream. Where an
+     * internal redirect starts another one - proxy_intercept_errors with an
+     * error_page, X-Accel-Redirect - ngx_http_upstream_init_request() keeps
+     * the states of the earlier round and pushes a zeroed state between them.
+     * $upstream_addr shows the same thing: a colon between the rounds where a
+     * retry gets a comma.
+     *
+     * uscf here is the group of the round that finished, so an attempt from
+     * an earlier round would be filed under the wrong group. The zeroed state
+     * is the boundary, and its peer is what makes it recognisable.
+     */
 
-    for (i = 0; i < r->upstream_states->nelts; i++) {
+    states = r->upstream_states->elts;
+    n = 0;
+
+    for (i = r->upstream_states->nelts; i > 0; i--) {
+        if (states[i - 1].peer == NULL) {
+            n = i;
+            break;
+        }
+    }
+
+    for (i = n; i < r->upstream_states->nelts; i++) {
 
         state = &states[i];
 
         if (state->peer == NULL) {
 
-            /* nothing to key on. See the note above: no traffic gets here */
+            /* nothing to key on. The walk starts past the last of these */
 
             continue;
         }

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -10,9 +10,9 @@
 
 
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
-    ngx_str_t *key, unsigned type);
+    ngx_str_t *key, unsigned type, ngx_http_upstream_state_t *state);
 static ngx_int_t ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init);
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init, ngx_msec_int_t ms);
 
 #if (NGX_HTTP_CACHE)
 static void ngx_http_vhost_traffic_status_shm_get_cache_size(ngx_http_request_t *r,
@@ -128,15 +128,18 @@ ngx_http_vhost_traffic_status_shm_info(ngx_http_request_t *r,
 
 static ngx_int_t
 ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
-    ngx_str_t *key, unsigned type)
+    ngx_str_t *key, unsigned type, ngx_http_upstream_state_t *state)
 {
     size_t                                     size;
     unsigned                                   init;
     uint32_t                                   hash;
+    ngx_uint_t                                 status;
+    ngx_msec_int_t                             ms;
     ngx_int_t                                  status_code_slot;
     ngx_slab_pool_t                           *shpool;
     ngx_rbtree_node_t                         *node, *lrun;
     ngx_http_vhost_traffic_status_ctx_t       *ctx;
+    ngx_http_upstream_state_t                 *ustate;
     ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
     ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
@@ -155,14 +158,17 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     shpool = (ngx_slab_pool_t *) vtscf->shm_zone->shm.addr;
 
 
+    /* the status of the attempt where there is one, of the request otherwise */
+    status = (state != NULL) ? state->status : r->headers_out.status;
+
     status_code_slot = 0;
     if (ctx->measure_all_status_codes) {
-        if (r->headers_out.status >= 100 && r->headers_out.status < 600) {
+        if (status >= 100 && status < 600) {
             // slot 0 is reserved to other status codes <100 and >600
-            status_code_slot = r->headers_out.status - 99;
+            status_code_slot = status - 99;
         }
     } else if (ctx->measure_status_codes != NULL) {
-        status_code_slot = ngx_http_vhost_traffic_status_find_status_code_slot(r->headers_out.status,
+        status_code_slot = ngx_http_vhost_traffic_status_find_status_code_slot(status,
                                                                               ctx->measure_status_codes);
     }
 
@@ -256,7 +262,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
             vtsn->stat_status_code_length = ctx->measure_status_codes->nelts;
         }
 
-        ngx_http_vhost_traffic_status_node_init(r, vtsn, status_code_slot);
+        ngx_http_vhost_traffic_status_node_init(r, vtsn, status_code_slot, state);
 
         vtsn->stat_upstream.type = type;
         ngx_memcpy(vtsn->data, key->data, key->len);
@@ -268,7 +274,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     } else {
         init = NGX_HTTP_VHOST_TRAFFIC_STATUS_NODE_FIND;
         vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
-        ngx_http_vhost_traffic_status_node_set(r, vtsn, status_code_slot);
+        ngx_http_vhost_traffic_status_node_set(r, vtsn, status_code_slot, state);
     }
 
     /* set addition */
@@ -278,7 +284,23 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA:
     case NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG:
-        (void) ngx_http_vhost_traffic_status_shm_add_node_upstream(r, vtsn, init);
+
+        /*
+         * Each attempt gets its own response time. The one that served the
+         * client arrives here with state NULL, and r->upstream->state is the
+         * last element of r->upstream_states, which is that same attempt.
+         *
+         * This used to be the sum over every attempt, given to whichever peer
+         * answered, so a peer was charged for the time spent failing on the
+         * peers before it.
+         */
+
+        ustate = (state != NULL) ? state
+                 : (r->upstream != NULL ? r->upstream->state : NULL);
+
+        ms = ngx_http_vhost_traffic_status_upstream_state_response_time(ustate);
+
+        (void) ngx_http_vhost_traffic_status_shm_add_node_upstream(r, vtsn, init, ms);
         break;
 
 #if (NGX_HTTP_CACHE)
@@ -300,14 +322,12 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
 static ngx_int_t
 ngx_http_vhost_traffic_status_shm_add_node_upstream(ngx_http_request_t *r,
-    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init)
+    ngx_http_vhost_traffic_status_node_t *vtsn, unsigned init, ngx_msec_int_t ms)
 {
-    ngx_msec_int_t  ms;
     ngx_atomic_t    oresponse_time_counter;
 
     /* only the response time counter is compared below */
     oresponse_time_counter = vtsn->stat_upstream.response_time_counter;
-    ms = ngx_http_vhost_traffic_status_upstream_response_time(r);
 
     ngx_http_vhost_traffic_status_node_time_queue_insert(&vtsn->stat_upstream.response_times,
                                                          ms);
@@ -481,7 +501,7 @@ ngx_http_vhost_traffic_status_shm_add_filter_node(ngx_http_request_t *r,
             }
         }
 
-        rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type);
+        rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type, NULL);
         if (rc != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "shm_add_filter_node::shm_add_node(\"%V\") failed", &key);
@@ -525,7 +545,7 @@ ngx_http_vhost_traffic_status_shm_add_server(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    return ngx_http_vhost_traffic_status_shm_add_node(r, &key, type);
+    return ngx_http_vhost_traffic_status_shm_add_node(r, &key, type, NULL);
 }
 
 
@@ -573,7 +593,7 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
     ngx_str_t                      *host, key, dst;
     ngx_uint_t                      i;
     ngx_http_upstream_t            *u;
-    ngx_http_upstream_state_t      *state;
+    ngx_http_upstream_state_t      *state, *states;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
 
@@ -620,40 +640,75 @@ ngx_http_vhost_traffic_status_shm_add_upstream(ngx_http_request_t *r)
 
 found:
 
-    state = u->state;
-    if (state->peer == NULL) {
+    if (u->state->peer == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "shm_add_upstream::peer failed");
         return NGX_ERROR;
     }
 
-    dst.len = (uscf->port ? 0 : uscf->host.len + sizeof("@") - 1) + state->peer->len;
-    dst.data = ngx_pnalloc(r->pool, dst.len);
-    if (dst.data == NULL) {
-        return NGX_ERROR;
-    }
+    /*
+     * Every attempt, not only the one that answered. A request that
+     * proxy_next_upstream passed on used to record nothing at all against the
+     * peer it was passed on from, which is the peer an operator looks for
+     * first (#388).
+     *
+     * The counters of a group therefore add up to attempts rather than to
+     * client requests, which is what $upstream_addr has always reported.
+     */
 
-    p = dst.data;
-    if (uscf->port) {
-        p = ngx_cpymem(p, state->peer->data, state->peer->len);
-        type = NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA;
+    states = r->upstream_states->elts;
 
-    } else {
-        p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
-        *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
-        p = ngx_cpymem(p, state->peer->data, state->peer->len);
-        type = NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG;
-    }
+    for (i = 0; i < r->upstream_states->nelts; i++) {
 
-    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
-    if (rc != NGX_OK) {
-        return NGX_ERROR;
-    }
+        state = &states[i];
 
-    rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type);
-    if (rc != NGX_OK) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                      "shm_add_upstream::shm_add_node(\"%V\") failed", &key);
+        if (state->peer == NULL) {
+
+            /*
+             * An attempt that never reached a peer - no address was left to
+             * try, or the resolver had nothing. There is nothing to key on.
+             */
+
+            continue;
+        }
+
+        dst.len = (uscf->port ? 0 : uscf->host.len + sizeof("@") - 1)
+                  + state->peer->len;
+        dst.data = ngx_pnalloc(r->pool, dst.len);
+        if (dst.data == NULL) {
+            return NGX_ERROR;
+        }
+
+        p = dst.data;
+        if (uscf->port) {
+            p = ngx_cpymem(p, state->peer->data, state->peer->len);
+            type = NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UA;
+
+        } else {
+            p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
+            *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
+            p = ngx_cpymem(p, state->peer->data, state->peer->len);
+            type = NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG;
+        }
+
+        rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst,
+                                                             type);
+        if (rc != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        /*
+         * The attempt that served the client is counted as the client
+         * request, as it always was. The others are counted as themselves.
+         */
+
+        rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type,
+                 (state == u->state) ? NULL : state);
+
+        if (rc != NGX_OK) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "shm_add_upstream::shm_add_node(\"%V\") failed", &key);
+        }
     }
 
     return NGX_OK;
@@ -711,7 +766,7 @@ ngx_http_vhost_traffic_status_shm_add_cache(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type);
+    rc = ngx_http_vhost_traffic_status_shm_add_node(r, &key, type, NULL);
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "shm_add_cache::shm_add_node(\"%V\") failed", &key);

--- a/t/045.upstream_next_attempts.t
+++ b/t/045.upstream_next_attempts.t
@@ -16,7 +16,7 @@
 
 use Test::Nginx::Socket;
 
-plan tests => repeat_each() * 24;
+plan tests => repeat_each() * 26;
 no_shuffle();
 run_tests();
 
@@ -163,3 +163,50 @@ __DATA__
     qr/\Aonly\z/,
     qr/"server":"127\.0\.0\.1:1985","requestCounter":2,"inBytes":[1-9]\d*,"outBytes":[1-9]\d*,"responses":\{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0\}/,
 ]
+
+=== TEST 5: an internal redirect to another upstream keeps its peers apart
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "fallback";
+        }
+    }
+
+    upstream first {
+        server 127.0.0.1:1981;
+    }
+
+    upstream second {
+        server 127.0.0.1:1985;
+    }
+--- config
+    location /up {
+        proxy_intercept_errors on;
+        error_page 502 = @fb;
+        proxy_pass http://first/;
+    }
+    location @fb {
+        proxy_pass http://second;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\Afallback\z/,
+    qr/"second":\[\{"server":"127\.0\.0\.1:1985"[^\]]*\}\]/,
+]
+
+# r->upstream_states is request-wide. Where an internal redirect starts a
+# second upstream, nginx keeps the states of the first and pushes a zeroed one
+# between them, so a walk from index 0 files the peers of `first` under
+# `second` - the group the current request ended up in. The assertion is that
+# the array for `second` holds one entry and it is its own server.

--- a/t/045.upstream_next_attempts.t
+++ b/t/045.upstream_next_attempts.t
@@ -16,7 +16,7 @@
 
 use Test::Nginx::Socket;
 
-plan tests => repeat_each() * 26;
+plan tests => repeat_each() * 28;
 no_shuffle();
 run_tests();
 
@@ -202,7 +202,7 @@ __DATA__
 --- response_body_like eval
 [
     qr/\Afallback\z/,
-    qr/"second":\[\{"server":"127\.0\.0\.1:1985"[^\]]*\}\]/,
+    qr/(?=.*"second":\[\{"server":"127\.0\.0\.1:1985")(?!.*,\{"server":"127\.0\.0\.1:1981")/s,
 ]
 
 # r->upstream_states is request-wide. Where an internal redirect starts a

--- a/t/045.upstream_next_attempts.t
+++ b/t/045.upstream_next_attempts.t
@@ -1,0 +1,165 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# shm_add_upstream() recorded u->state, the state of the last attempt, so a
+# request that proxy_next_upstream passed on recorded nothing at all against
+# the peer it was passed on from - the peer an operator looks for first (#388).
+#
+# The upstream here has a primary with nothing listening on it and a backup
+# that answers, which makes the order of the attempts the same for every
+# request: the primary is refused, the backup serves. max_fails=0 keeps the
+# primary in play rather than having it marked down after the first failure.
+#
+# What each peer is expected to hold:
+#
+#   primary   requestCounter and 5xx, no bytes, since it served no client
+#   backup    requestCounter and 2xx and the bytes, as before this change
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * 24;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: the peer that was passed on is counted at all
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "backup";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1981 max_fails=0;
+        server 127.0.0.1:1985 backup;
+    }
+--- config
+    location /up {
+        proxy_next_upstream error timeout;
+        proxy_pass http://backend/;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /up', 'GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\Abackup\z/,
+    qr/\Abackup\z/,
+    qr/"server":"127\.0\.0\.1:1981","requestCounter":2/,
+]
+
+# The entry itself is written whether or not anything was counted, the display
+# enumerating the servers of the group, so asserting that the address appears
+# would pass on master as well. The counter is what says the attempt was seen.
+
+=== TEST 2: it holds the status of its own attempt, not the client's
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "backup";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1981 max_fails=0;
+        server 127.0.0.1:1985 backup;
+    }
+--- config
+    location /up {
+        proxy_next_upstream error timeout;
+        proxy_pass http://backend/;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /up', 'GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\Abackup\z/,
+    qr/\Abackup\z/,
+    qr/"server":"127\.0\.0\.1:1981","requestCounter":2,"inBytes":0,"outBytes":0,"responses":\{"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":2\}/,
+]
+
+=== TEST 3: the peer that answered is counted as it always was
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "backup";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1981 max_fails=0;
+        server 127.0.0.1:1985 backup;
+    }
+--- config
+    location /up {
+        proxy_next_upstream error timeout;
+        proxy_pass http://backend/;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /up', 'GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\Abackup\z/,
+    qr/\Abackup\z/,
+    qr/"server":"127\.0\.0\.1:1985","requestCounter":2,"inBytes":[1-9]\d*,"outBytes":[1-9]\d*,"responses":\{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0\}/,
+]
+
+=== TEST 4: a request that needs no second attempt is unchanged
+--- http_config
+    vhost_traffic_status_zone;
+
+    server {
+        listen 1985;
+
+        location / {
+            return 200 "only";
+        }
+    }
+
+    upstream backend {
+        server 127.0.0.1:1985;
+    }
+--- config
+    location /up {
+        proxy_pass http://backend/;
+    }
+    location /status {
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format json;
+        access_log off;
+    }
+--- request eval
+['GET /up', 'GET /up', 'GET /status/format/json']
+--- response_body_like eval
+[
+    qr/\Aonly\z/,
+    qr/\Aonly\z/,
+    qr/"server":"127\.0\.0\.1:1985","requestCounter":2,"inBytes":[1-9]\d*,"outBytes":[1-9]\d*,"responses":\{"1xx":0,"2xx":2,"3xx":0,"4xx":0,"5xx":0\}/,
+]


### PR DESCRIPTION
Fixes #388.

`shm_add_upstream()` recorded `u->state`, the state of the last attempt, and called `shm_add_node()` once. A request that `proxy_next_upstream` passed on recorded nothing at all against the peer it was passed on from - which is the peer an operator looks for first.

**This is pushed as the test first and the fix second, so that the red and the green are both on the record.** The first commit is the test alone.

## README already said what this makes true

The field reference has defined `requestCounter` for an upstream server since long before this:

> **requestCounter** - The total number of client connections forwarded to this server.

A connection forwarded to a peer that then refused it *was* forwarded to that peer. master did not count it, so master contradicted its own documentation. The change is not a new definition; it is the implementation catching up, and the README wording is extended to say so explicitly rather than left to be inferred.

## What each attempt contributes

| | |
| --- | --- |
| the attempt that served the client | the client request, exactly as before |
| an attempt that was passed on | `requestCounter`, `responses` from its own `state->status`, and its own response time |

An attempt that was passed on served no client, so the figures that describe the client request - the bytes either way, how long it took, what the cache did with it - have nothing to say about it and are left alone.

That is also what keeps this free of version guards. `status`, `response_time` and `peer` have been in `ngx_http_upstream_state_t` since 0.3.3; the per-attempt byte counts only arrived in 1.11.4 and 1.15.8, and this does not need them. Reading them would have put a `#if nginx_version` in the request path for a README that starts at 1.4.x - the shape of #389.

The status of a passed-on attempt is the one `$upstream_status` logs for it. `ngx_http_upstream_next()` sets it: 502 where the connection was refused, 504 where it timed out, and the actual 500/503/403/404/429 where that is what triggered the retry.

## Measured

nginx 1.31.4, three requests through a group whose first peer refuses them.

| peer | master | with this |
| --- | --- | --- |
| the one that refused | `requestCounter 0`, no entry in the tree | `requestCounter`, `5xx`, `inBytes 0`, `outBytes 0` |
| the one that answered | `requestCounter 3`, `2xx 3` | unchanged |

## Two numbers change

- **The counters of a group add up to attempts rather than to client requests.** `$upstream_addr` has always reported one address per attempt, and the workaround in #155 - `vhost_traffic_status_filter_by_set_key $upstream_addr` - already produced several entries per request for the same reason. This is the decision #388 asked to have settled before the patch.
- **`responseMsecCounter` of the peer that answered no longer includes the time spent failing on the peers before it.** It was the sum over every attempt, given to whichever peer answered. `upstream_response_time()` computed that sum and has no caller left, so it goes; what remains is a helper that reads a single state, used by both kinds of attempt.

## Tests

`t/045`, four blocks. Reverting the walk to the last attempt alone fails TEST 1 and TEST 2. TEST 3 and TEST 4 hold the paths this must not disturb and stay green under the same mutation, which is what they are for.

An earlier draft of TEST 1 asserted only that the peer's address appeared in the JSON. That passes on master - the display enumerates the servers of a group whether or not anything was counted - so it was changed to read the counter.

Locally: the same 12 environmental failures as master, none new.

## Not in this

Whether the attempt that *did* serve the client should also be described from the upstream side - `state->status` rather than the status the client was sent, and `state->bytes_received`/`bytes_sent` rather than the client's bytes. That is a change of what an upstreamZone means, it moves `inBytes`/`outBytes` for every configuration, and it needs the version guards this does not. It should be argued on its own.
