### PR TITLE
refactor: an unused queue helper, and one place to report a full zone

### DIFF
--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -638,14 +638,6 @@ ngx_http_vhost_traffic_status_node_time_queue_pop(
 }
 
 
-ngx_int_t
-ngx_http_vhost_traffic_status_node_time_queue_rear(
-    ngx_http_vhost_traffic_status_node_time_queue_t *q)
-{
-    return (q->rear > 0) ? (q->rear - 1) : (NGX_HTTP_VHOST_TRAFFIC_STATUS_DEFAULT_QUEUE_LEN - 1);
-}
-
-
 void
 ngx_http_vhost_traffic_status_node_time_queue_insert(
     ngx_http_vhost_traffic_status_node_time_queue_t *q,

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -186,9 +186,6 @@ ngx_int_t ngx_http_vhost_traffic_status_node_time_queue_push(
 ngx_int_t ngx_http_vhost_traffic_status_node_time_queue_pop(
     ngx_http_vhost_traffic_status_node_time_queue_t *q,
     ngx_http_vhost_traffic_status_node_time_t *x);
-ngx_int_t ngx_http_vhost_traffic_status_node_time_queue_rear(
-    ngx_http_vhost_traffic_status_node_time_queue_t *q);
-
 ngx_msec_t ngx_http_vhost_traffic_status_node_time_queue_average(
     ngx_http_vhost_traffic_status_node_time_queue_t *q,
     ngx_int_t method, ngx_msec_t period);

--- a/src/ngx_http_vhost_traffic_status_shm.c
+++ b/src/ngx_http_vhost_traffic_status_shm.c
@@ -26,6 +26,35 @@ static ngx_int_t ngx_http_vhost_traffic_status_shm_add_filter_node(ngx_http_requ
     ngx_array_t *filter_keys);
 
 
+/*
+ * Reports a node the zone had no room for, together with what the zone holds
+ * at the time, which is the figure that says whether it is worth enlarging.
+ *
+ * The caller holds the mutex of the zone, as shm_info() walks the tree. There
+ * is nothing to say where the report itself cannot be allocated, and the
+ * caller returns the same failure either way.
+ */
+
+static void
+ngx_http_vhost_traffic_status_shm_alloc_failed(ngx_http_request_t *r)
+{
+    ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
+
+    shm_info = ngx_pcalloc(r->pool,
+                           sizeof(ngx_http_vhost_traffic_status_shm_info_t));
+    if (shm_info == NULL) {
+        return;
+    }
+
+    ngx_http_vhost_traffic_status_shm_info(r, shm_info);
+
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                  "shm_add_node::ngx_slab_alloc_locked() failed: "
+                  "used_size[%ui], used_node[%ui]",
+                  shm_info->used_size, shm_info->used_node);
+}
+
+
 void
 ngx_http_vhost_traffic_status_shm_info_node(ngx_http_request_t *r,
     ngx_http_vhost_traffic_status_shm_info_t *shm_info,
@@ -142,7 +171,6 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
     ngx_http_upstream_state_t                 *ustate;
     ngx_http_vhost_traffic_status_node_t      *vtsn;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
-    ngx_http_vhost_traffic_status_shm_info_t  *shm_info;
 #if (NGX_HTTP_CACHE)
     ngx_atomic_uint_t                          cache_max_size, cache_used_size;
 #endif
@@ -215,18 +243,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
 
         node = ngx_slab_alloc_locked(shpool, size);
         if (node == NULL) {
-            shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
-            if (shm_info == NULL) {
-                ngx_shmtx_unlock(&shpool->mutex);
-                return NGX_ERROR;
-            }
-
-            ngx_http_vhost_traffic_status_shm_info(r, shm_info);
-
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "shm_add_node::ngx_slab_alloc_locked() failed: "
-                          "used_size[%ui], used_node[%ui]",
-                          shm_info->used_size, shm_info->used_node);
+            ngx_http_vhost_traffic_status_shm_alloc_failed(r);
 
             ngx_shmtx_unlock(&shpool->mutex);
             return NGX_ERROR;
@@ -241,19 +258,7 @@ ngx_http_vhost_traffic_status_shm_add_node(ngx_http_request_t *r,
         if (ctx->measure_status_codes != NULL) {
             vtsn->stat_status_code_counter = ngx_slab_alloc_locked(shpool, sizeof(ngx_atomic_t) * (ctx->measure_status_codes->nelts + 1));
             if (vtsn->stat_status_code_counter == NULL) {
-                shm_info = ngx_pcalloc(r->pool, sizeof(ngx_http_vhost_traffic_status_shm_info_t));
-                if (shm_info == NULL) {
-                    ngx_slab_free_locked(shpool, node);
-                    ngx_shmtx_unlock(&shpool->mutex);
-                    return NGX_ERROR;
-                }
-
-                ngx_http_vhost_traffic_status_shm_info(r, shm_info);
-
-                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                              "shm_add_node::ngx_slab_alloc_locked() failed: "
-                              "used_size[%ui], used_node[%ui]",
-                              shm_info->used_size, shm_info->used_node);
+                ngx_http_vhost_traffic_status_shm_alloc_failed(r);
 
                 ngx_slab_free_locked(shpool, node);
                 ngx_shmtx_unlock(&shpool->mutex);


### PR DESCRIPTION
Two cleanups in code nobody has had a reason to open lately. Neither changes
behaviour; both are here because they were found while reading the module,
not because anything went wrong.

**`node_time_queue_rear()` is dead.** It returns the index of the element
last written to the time queue. Nothing calls it, and nothing does in the
history this tree carries — the readers average over the whole queue and the
writers use `push()`, which keeps `rear` itself. It is not static, so no
build reports it, and the declaration in `node.h` is what makes it look like
part of the interface of the queue.

**`shm_add_node()` reported a full zone twice, identically.** It allocates
twice under the mutex — the node, and the array of status code counters
where `measure_status_codes` is configured — and each failure was followed
by the same seventeen lines: allocate a `shm_info_t`, walk the tree to fill
it, log `used_size` and `used_node`, unlock, return `NGX_ERROR`. The report
is now a function of its own. What is logged, and what happens when the
report itself cannot be allocated — nothing is logged, and `NGX_ERROR` is
still returned — are unchanged. The message keeps naming `shm_add_node()`,
which is where a reader of an error log needs to arrive.

It is a function rather than a macro so that the mutex requirement, which
comes from `shm_info()` walking the tree rather than from anything in the
report, has somewhere to be written down.

### Checked

Built with `-Werror` against nginx 1.30.4 as configured by CI. The suite
gives the same verdict for every file as master does.

There is no red commit to show: neither change is meant to be observable, so
no test can distinguish this from master. The second one is covered
incidentally by `t/033` and `t/039`, which read `used_node` through the same
`shm_info()` path.
