### PR TITLE
refactor: one walk over the peers an upstream group holds

### DIFF
--- a/config
+++ b/config
@@ -7,6 +7,7 @@ HTTP_VTS_SRCS=" \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_string.c             \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_shm.c                \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_node.c               \
+                 $ngx_addon_dir/src/ngx_http_vhost_traffic_status_upstream.c           \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_filter.c             \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_control.c            \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_limit.c              \
@@ -23,6 +24,7 @@ HTTP_VTS_DEPS=" \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_string.h             \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_shm.h                \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_node.h               \
+                 $ngx_addon_dir/src/ngx_http_vhost_traffic_status_upstream.h           \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_filter.h             \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_control.h            \
                  $ngx_addon_dir/src/ngx_http_vhost_traffic_status_limit.h              \

--- a/src/ngx_http_vhost_traffic_status_control.c
+++ b/src/ngx_http_vhost_traffic_status_control.c
@@ -8,21 +8,19 @@
 #include "ngx_http_vhost_traffic_status_control.h"
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
-
-#if (NGX_HTTP_UPSTREAM_CHECK)
-#include "ngx_http_upstream_check_module.h"
-#endif
+#include "ngx_http_vhost_traffic_status_upstream.h"
 
 
-#if (NGX_HTTP_UPSTREAM_ZONE)
-static ngx_int_t ngx_http_vhost_traffic_status_control_peer_lookup(
-    ngx_http_upstream_rr_peers_t *peers, ngx_str_t *name,
-    ngx_http_upstream_server_t *usn);
-#endif
+/* the peer node_upstream_lookup() is after, and where the answer goes */
+typedef struct {
+    ngx_str_t                   *name;
+    ngx_http_upstream_server_t  *usn;
+} ngx_http_vhost_traffic_status_control_peer_t;
 
-static ngx_int_t ngx_http_vhost_traffic_status_control_server_lookup(
-    ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
-    ngx_http_upstream_server_t *usn);
+
+static ngx_int_t ngx_http_vhost_traffic_status_control_peer_match(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn, void *data);
 
 static void ngx_http_vhost_traffic_status_node_status_all(
     ngx_http_vhost_traffic_status_control_t *control);
@@ -54,134 +52,43 @@ static void ngx_http_vhost_traffic_status_node_reset_zone(
     ngx_http_vhost_traffic_status_control_t *control);
 
 
-#if (NGX_HTTP_UPSTREAM_ZONE)
-
 /*
- * Fills in what the control interface answers with for the peer named `name`,
- * looking through the peers the upstream group has right now rather than the
- * server lines it was configured from.
- *
- * The backup peers are a list of their own hanging off peers->next and a
- * `resolve` line makes peers in either of them, so both are walked. Which
- * list the peer was found in is what says whether it is a backup - a name
- * resolved at run time is not written down anywhere else.
+ * Fills in what the control interface answers with for the peer it is looking
+ * for, from the walk the display is written out of, so that the two cannot
+ * say different things about the same peer.
  */
 
 static ngx_int_t
-ngx_http_vhost_traffic_status_control_peer_lookup(
-    ngx_http_upstream_rr_peers_t *peers, ngx_str_t *name,
-    ngx_http_upstream_server_t *usn)
-{
-    ngx_int_t                     rc;
-    ngx_uint_t                    backup;
-    ngx_http_upstream_rr_peer_t  *peer;
-
-    rc = NGX_DECLINED;
-
-    for (backup = 0; peers && rc != NGX_OK; peers = peers->next, backup = 1) {
-
-        ngx_http_upstream_rr_peers_rlock(peers);
-
-        for (peer = peers->peer; peer; peer = peer->next) {
-
-            if (peer->name.len != name->len) {
-                continue;
-            }
-
-            if (ngx_strncmp(peer->name.data, name->data, name->len) != 0) {
-                continue;
-            }
-
-#if nginx_version > 1007001
-
-            /*
-             * name rather than peer->name: the name of a peer lives in the
-             * zone of the upstream and a re-resolve can hand it back to the
-             * slab as soon as the lock below is released, while the caller
-             * reads this afterwards to write its answer. The two were just
-             * compared byte for byte, and name belongs to the request.
-             */
-
-            usn->name = *name;
-#endif
-
-            usn->weight = peer->weight;
-            usn->max_fails = peer->max_fails;
-            usn->fail_timeout = peer->fail_timeout;
-            usn->backup = backup;
-
-#if (NGX_HTTP_UPSTREAM_CHECK)
-            usn->down = ngx_http_upstream_check_peer_down(peer->check_index)
-                        ? 1 : 0;
-#else
-
-            /*
-             * max_fails 0 turns the counting off, which nginx reads as never
-             * taking the peer out; without the guard the comparison holds
-             * from the first request and every such peer is called down
-             */
-
-            usn->down = (peer->down
-                         || (peer->max_fails
-                             && peer->fails >= peer->max_fails));
-#endif
-
-            rc = NGX_OK;
-
-            break;
-        }
-
-        ngx_http_upstream_rr_peers_unlock(peers);
-    }
-
-    return rc;
-}
-
-#endif
-
-
-/*
- * The same, from the server lines of the group, which is what the display
- * reads when the group has no zone to read instead.
- */
-
-static ngx_int_t
-ngx_http_vhost_traffic_status_control_server_lookup(
+ngx_http_vhost_traffic_status_control_peer_match(ngx_http_request_t *r,
     ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
-    ngx_http_upstream_server_t *usn)
+    ngx_http_upstream_server_t *usn, void *data)
 {
-    ngx_uint_t                   i, j;
-    ngx_http_upstream_server_t  *us;
+    ngx_http_vhost_traffic_status_control_peer_t  *cp = data;
 
-    us = uscf->servers->elts;
-
-    for (i = 0; i < uscf->servers->nelts; i++) {
-
-        /* a server gives one peer per address its name resolves to */
-
-        for (j = 0; j < us[i].naddrs; j++) {
-
-            if (us[i].addrs[j].name.len != name->len) {
-                continue;
-            }
-
-            if (ngx_strncmp(us[i].addrs[j].name.data, name->data, name->len)
-                != 0)
-            {
-                continue;
-            }
-
-            *usn = us[i];
-
-#if nginx_version > 1007001
-            usn->name = us[i].addrs[j].name;
-#endif
-
-            return NGX_OK;
-        }
+    if (name->len != cp->name->len
+        || ngx_strncmp(name->data, cp->name->data, name->len) != 0)
+    {
+        return NGX_OK;
     }
 
-    return NGX_DECLINED;
+    *cp->usn = *usn;
+
+#if nginx_version > 1007001
+
+    /*
+     * cp->name rather than the name of the peer: the name of a peer lives in
+     * the zone of the upstream and a re-resolve can hand it back to the slab
+     * as soon as the walk releases its lock, while the caller reads this
+     * afterwards to write its answer. The two were just compared byte for
+     * byte, and cp->name belongs to the request.
+     */
+
+    cp->usn->name = *cp->name;
+#endif
+
+    /* found, and there is no reason to look at the rest of the group */
+
+    return NGX_DONE;
 }
 
 
@@ -195,6 +102,7 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
     ngx_uint_t                      i;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
+    ngx_http_vhost_traffic_status_control_peer_t  cp;
 
     umcf = ngx_http_get_module_main_conf(control->r, ngx_http_upstream_module);
     uscfp = umcf->upstreams.elts;
@@ -243,35 +151,14 @@ ngx_http_vhost_traffic_status_node_upstream_lookup(
         if (uscf->host.len == usg.len) {
             if (ngx_strncmp(uscf->host.data, usg.data, usg.len) == 0) {
 
-                /*
-                 * The peers of the group where it has a zone, backups
-                 * included, and the server lines where it has not - the two
-                 * sources the display is written out of, so that the two
-                 * cannot disagree about a peer.
-                 *
-                 * The two are exclusive rather than one falling back to the
-                 * other, and a server line that resolves its name at run time
-                 * is why: ngx_http_upstream_server() leaves a placeholder
-                 * holding the port and addrs[0].name is never set, so reading
-                 * the lines of a group that has a zone would answer for peers
-                 * that are not there and miss the ones that are.
-                 */
+                cp.name = &ush;
+                cp.usn = usn;
 
-#if (NGX_HTTP_UPSTREAM_ZONE)
-                if (uscf->shm_zone != NULL) {
-                    rc = ngx_http_vhost_traffic_status_control_peer_lookup(
-                             uscf->peer.data, &ush, usn);
+                rc = ngx_http_vhost_traffic_status_upstream_peers_walk(
+                         control->r, uscf,
+                         ngx_http_vhost_traffic_status_control_peer_match, &cp);
 
-                } else {
-                    rc = ngx_http_vhost_traffic_status_control_server_lookup(
-                             uscf, &ush, usn);
-                }
-#else
-                rc = ngx_http_vhost_traffic_status_control_server_lookup(uscf,
-                         &ush, usn);
-#endif
-
-                if (rc != NGX_OK) {
+                if (rc != NGX_DONE) {
 
                     /*
                      * A peer the group does not hold: one a balancer_by_lua

--- a/src/ngx_http_vhost_traffic_status_display.c
+++ b/src/ngx_http_vhost_traffic_status_display.c
@@ -11,6 +11,7 @@
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
 #include "ngx_http_vhost_traffic_status_control.h"
+#include "ngx_http_vhost_traffic_status_upstream.h"
 
 
 static ngx_int_t ngx_http_vhost_traffic_status_display_handler(ngx_http_request_t *r);
@@ -568,65 +569,49 @@ ngx_http_vhost_traffic_status_display_handler_default(ngx_http_request_t *r)
 }
 
 
+static ngx_int_t
+ngx_http_vhost_traffic_status_display_count_upstream_peer(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf,
+    ngx_str_t *name, ngx_http_upstream_server_t *usn, void *data)
+{
+    (*(ngx_uint_t *) data)++;
+
+    return NGX_OK;
+}
+
+
+/*
+ * How many upstream peers the display writes, which is what the buffer has to
+ * be sized for. The count comes from the same walk the writer uses: counting
+ * the primary peers and then every server line was slack while the backups
+ * came from the lines, and it stopped being slack when they started coming
+ * from peers->next. A name that resolves to more addresses than the one
+ * placeholder its line leaves behind is then written without having been
+ * counted, and display_buffer_check() drops the entries that do not fit -
+ * valid JSON, missing peers.
+ */
+
 ngx_int_t
 ngx_http_vhost_traffic_status_display_get_upstream_nelts(ngx_http_request_t *r)
 {
-    ngx_uint_t                      i, j, n;
-    ngx_http_upstream_server_t     *us;
-#if (NGX_HTTP_UPSTREAM_ZONE)
-    ngx_http_upstream_rr_peer_t    *peer;
-    ngx_http_upstream_rr_peers_t   *peers;
-#endif
+    ngx_uint_t                      i, n;
     ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
 
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
     uscfp = umcf->upstreams.elts;
 
-    for (i = 0, j = 0, n = 0; i < umcf->upstreams.nelts; i++) {
+    n = 0;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
 
         uscf = uscfp[i];
 
         /* groups */
         if (uscf->servers && !uscf->port) {
-            us = uscf->servers->elts;
-
-#if (NGX_HTTP_UPSTREAM_ZONE)
-            if (uscf->shm_zone == NULL) {
-                goto not_supported;
-            }
-
-            /*
-             * Both lists, and the server lines are not read at all: this has
-             * to count what display_set_upstream_group() writes. Counting the
-             * primary peers and then every server line was slack while the
-             * backups came from the lines, and it stopped being slack when
-             * they started coming from peers->next. A name that resolves to
-             * more addresses than the one placeholder its line leaves behind
-             * is then written without having been counted, and the entries
-             * that do not fit are dropped by display_buffer_check().
-             */
-
-            for (peers = uscf->peer.data; peers; peers = peers->next) {
-
-                ngx_http_upstream_rr_peers_rlock(peers);
-
-                for (peer = peers->peer; peer; peer = peer->next) {
-                    n++;
-                }
-
-                ngx_http_upstream_rr_peers_unlock(peers);
-            }
-
-            continue;
-
-not_supported:
-
-#endif
-
-            for (j = 0; j < uscf->servers->nelts; j++) {
-                n += us[j].naddrs;
-            }
+            (void) ngx_http_vhost_traffic_status_upstream_peers_walk(r, uscf,
+                       ngx_http_vhost_traffic_status_display_count_upstream_peer,
+                       &n);
         }
     }
 

--- a/src/ngx_http_vhost_traffic_status_display_json.c
+++ b/src/ngx_http_vhost_traffic_status_display_json.c
@@ -9,10 +9,7 @@
 #include "ngx_http_vhost_traffic_status_filter.h"
 #include "ngx_http_vhost_traffic_status_display_json.h"
 #include "ngx_http_vhost_traffic_status_display.h"
-
-#if (NGX_HTTP_UPSTREAM_CHECK)
-#include "ngx_http_upstream_check_module.h"
-#endif
+#include "ngx_http_vhost_traffic_status_upstream.h"
 
 
 /*
@@ -45,6 +42,19 @@ typedef struct {
 } ngx_http_vhost_traffic_status_gone_peer_t;
 
 
+/* what set_upstream_group() carries through the walk of one group */
+typedef struct {
+    u_char                               *buf;
+    ngx_http_vhost_traffic_status_ctx_t  *ctx;
+} ngx_http_vhost_traffic_status_display_upstream_t;
+
+
+static ngx_int_t ngx_http_vhost_traffic_status_display_set_upstream_peer(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn, void *data);
+static ngx_int_t ngx_http_vhost_traffic_status_display_keep_upstream_peer(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn, void *data);
 static ngx_array_t *ngx_http_vhost_traffic_status_display_upstream_groups(
     ngx_http_request_t *r);
 static ngx_array_t *ngx_http_vhost_traffic_status_display_upstream_peer_names(
@@ -612,53 +622,97 @@ ngx_http_vhost_traffic_status_display_set_upstream_alone(ngx_http_request_t *r,
 }
 
 
+/*
+ * Writes one peer of an upstream group.
+ *
+ * The key of a peer is the name of its group, the separator and the name of
+ * the peer. This used to be built in one buffer held for the whole walk,
+ * sized for the longest group name and an address and a port, on the reading
+ * that a peer is never named anything longer. A unix socket is named by its
+ * path, which passes that easily, and the overflow did more than run off the
+ * end: node_generate_key() takes the key from the same pool with ngx_pcalloc,
+ * which zeroes a region overlapping the tail just written, so the name was cut
+ * short, the lookup missed, and the peer read as though it had served nothing
+ * (#378).
+ *
+ * Each key is now given the room it needs where it is built.
+ */
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_display_set_upstream_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn, void *data)
+{
+    u_char                                *p;
+    uint32_t                               hash;
+    ngx_int_t                              rc;
+    ngx_str_t                              key, dst;
+    ngx_rbtree_node_t                     *node;
+    ngx_http_vhost_traffic_status_node_t  *vtsn;
+    ngx_http_vhost_traffic_status_display_upstream_t  *u = data;
+
+    dst.len = uscf->host.len + sizeof("@") - 1 + name->len;
+    dst.data = ngx_pnalloc(r->pool, dst.len);
+    if (dst.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    p = dst.data;
+    p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
+    *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
+    p = ngx_cpymem(p, name->data, name->len);
+
+    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst,
+             NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG);
+    if (rc != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    hash = ngx_crc32_short(key.data, key.len);
+    node = ngx_http_vhost_traffic_status_node_lookup(u->ctx->rbtree, &key, hash);
+
+    /* a peer that has served nothing yet is written with the zeros of no node */
+    vtsn = (node != NULL)
+           ? (ngx_http_vhost_traffic_status_node_t *) &node->color
+           : NULL;
+
+#if nginx_version > 1007001
+    u->buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, u->buf,
+                 usn, vtsn);
+#else
+    u->buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, u->buf,
+                 usn, vtsn, name);
+#endif
+
+    return NGX_OK;
+}
+
+
 u_char *
 ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
     u_char *buf)
 {
-    u_char                                *p, *o, *s;
-    uint32_t                               hash;
-    unsigned                               type, zone;
+    u_char                                *o, *s;
     ngx_int_t                              rc;
-    ngx_str_t                              key, dst;
-    ngx_uint_t                             i, j, k;
-    ngx_rbtree_node_t                     *node;
-    ngx_http_upstream_server_t            *us, usn;
-#if (NGX_HTTP_UPSTREAM_ZONE)
-    ngx_uint_t                             backup;
-    ngx_http_upstream_rr_peer_t           *peer;
-    ngx_http_upstream_rr_peers_t          *peers;
-#endif
+    ngx_str_t                              key;
+    ngx_uint_t                             i;
     ngx_array_t                           *groups;
     ngx_http_vhost_traffic_status_upstream_group_t  *ug;
     ngx_http_upstream_srv_conf_t          *uscf, **uscfp;
     ngx_http_upstream_main_conf_t         *umcf;
-    ngx_http_vhost_traffic_status_ctx_t   *ctx;
-    ngx_http_vhost_traffic_status_node_t  *vtsn;
+    ngx_http_vhost_traffic_status_display_upstream_t  u;
 
-    ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+    u.buf = buf;
+    u.ctx = ngx_http_get_module_main_conf(r, ngx_http_vhost_traffic_status_module);
+
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
     uscfp = umcf->upstreams.elts;
-
-    /*
-     * The key of a peer is the name of its group, the separator and the name
-     * of the peer. This used to be built in one buffer held for the whole
-     * walk, sized for the longest group name and an address and a port, on
-     * the reading that a peer is never named anything longer. A unix socket
-     * is named by its path, which passes that easily, and the overflow did
-     * more than run off the end: node_generate_key() takes the key from the
-     * same pool with ngx_pcalloc, which zeroes a region overlapping the tail
-     * just written, so the name was cut short, the lookup missed, and the
-     * peer read as though it had served nothing (#378).
-     *
-     * Each key is now given the room it needs where it is built.
-     */
 
     groups = ngx_http_vhost_traffic_status_display_upstream_groups(r);
 
     if (groups != NULL) {
         ngx_http_vhost_traffic_status_display_collect_gone_peers(r,
-            ctx->rbtree->root, groups);
+            u.ctx->rbtree->root, groups);
     }
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
@@ -667,163 +721,21 @@ ngx_http_vhost_traffic_status_display_set_upstream_group(ngx_http_request_t *r,
 
         /* groups */
         if (uscf->servers && !uscf->port) {
-            us = uscf->servers->elts;
 
-            type = NGX_HTTP_VHOST_TRAFFIC_STATUS_UPSTREAM_UG;
+            o = u.buf;
 
-            o = buf;
+            u.buf = ngx_sprintf(u.buf,
+                                NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_S,
+                                &uscf->host);
+            s = u.buf;
 
-            buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_S,
-                              &uscf->host);
-            s = buf;
+            rc = ngx_http_vhost_traffic_status_upstream_peers_walk(r, uscf,
+                     ngx_http_vhost_traffic_status_display_set_upstream_peer,
+                     &u);
 
-            zone = 0;
-
-#if (NGX_HTTP_UPSTREAM_ZONE)
-            if (uscf->shm_zone == NULL) {
-                goto not_supported;
-            }
-
-            zone = 1;
-
-            peers = uscf->peer.data;
-
-            /*
-             * A peer that a `resolve` line makes at run time is not named by
-             * any server line, and nginx builds a resolve list for the backup
-             * servers too. Both lists are walked, and the flag comes from the
-             * one the peer was found in - the server lines cannot say it here.
-             */
-            for (backup = 0; peers; peers = peers->next, backup = 1) {
-
-                ngx_http_upstream_rr_peers_rlock(peers);
-
-                for (peer = peers->peer; peer; peer = peer->next) {
-                    dst.len = uscf->host.len + sizeof("@") - 1 + peer->name.len;
-                    dst.data = ngx_pnalloc(r->pool, dst.len);
-                    if (dst.data == NULL) {
-                        ngx_http_upstream_rr_peers_unlock(peers);
-                        return buf;
-                    }
-
-                    p = dst.data;
-                    p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
-                    *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
-                    p = ngx_cpymem(p, peer->name.data, peer->name.len);
-
-                    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
-                    if (rc != NGX_OK) {
-                        ngx_http_upstream_rr_peers_unlock(peers);
-                        return buf;
-                    }
-
-                    hash = ngx_crc32_short(key.data, key.len);
-                    node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
-
-                    usn.weight = peer->weight;
-                    usn.max_fails = peer->max_fails;
-                    usn.fail_timeout = peer->fail_timeout;
-                    usn.backup = backup;
-#if (NGX_HTTP_UPSTREAM_CHECK)
-                    if (ngx_http_upstream_check_peer_down(peer->check_index)) {
-                        usn.down = 1;
-
-                    } else {
-                        usn.down = 0;
-                    }
-#else
-                    /*
-                     * max_fails 0 turns the counting off, which nginx reads as
-                     * never taking the peer out; without the guard the comparison
-                     * holds from the first request and every such peer is called
-                     * down
-                     */
-                    usn.down = (peer->down
-                                || (peer->max_fails
-                                    && peer->fails >= peer->max_fails));
-#endif
-
-#if nginx_version > 1007001
-                    usn.name = peer->name;
-#endif
-
-                    if (node != NULL) {
-                        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
-#if nginx_version > 1007001
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn);
-#else
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn, &peer->name);
-#endif
-
-                    } else {
-#if nginx_version > 1007001
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL);
-#else
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL, &peer->name);
-#endif
-                    }
-
-                }
-
-                ngx_http_upstream_rr_peers_unlock(peers);
-            }
-
-not_supported:
-
-#endif
-
-            /*
-             * The server lines are read only when there is no zone to read
-             * instead. They used to supply the backup peers, which is where
-             * a resolving line went missing: it leaves an address whose name
-             * was never set, so what came out was an empty server name.
-             */
-            for (j = 0; !zone && j < uscf->servers->nelts; j++) {
-                usn = us[j];
-
-                /* for all A records */
-                for (k = 0; k < usn.naddrs; k++) {
-                    dst.len = uscf->host.len + sizeof("@") - 1
-                              + usn.addrs[k].name.len;
-                    dst.data = ngx_pnalloc(r->pool, dst.len);
-                    if (dst.data == NULL) {
-                        return buf;
-                    }
-
-                    p = dst.data;
-                    p = ngx_cpymem(p, uscf->host.data, uscf->host.len);
-                    *p++ = NGX_HTTP_VHOST_TRAFFIC_STATUS_KEY_SEPARATOR;
-                    p = ngx_cpymem(p, usn.addrs[k].name.data, usn.addrs[k].name.len);
-
-                    rc = ngx_http_vhost_traffic_status_node_generate_key(r->pool, &key, &dst, type);
-                    if (rc != NGX_OK) {
-                        return buf;
-                    }
-
-                    hash = ngx_crc32_short(key.data, key.len);
-                    node = ngx_http_vhost_traffic_status_node_lookup(ctx->rbtree, &key, hash);
-
-#if nginx_version > 1007001
-                    usn.name = usn.addrs[k].name;
-#endif
-
-                    if (node != NULL) {
-                        vtsn = (ngx_http_vhost_traffic_status_node_t *) &node->color;
-#if nginx_version > 1007001
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn);
-#else
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, vtsn, &usn.addrs[k].name);
-#endif
-
-                    } else {
-#if nginx_version > 1007001
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL);
-#else
-                        buf = ngx_http_vhost_traffic_status_display_set_upstream_node(r, buf, &usn, NULL, &usn.addrs[k].name);
-#endif
-                    }
-
-                }
+            /* out of memory, and what has been written so far is all there is */
+            if (rc != NGX_OK) {
+                return u.buf;
             }
 
             /*
@@ -837,43 +749,44 @@ not_supported:
                          groups, &uscf->host);
 
                 if (ug != NULL && ug->gone != NULL) {
-                    buf = ngx_http_vhost_traffic_status_display_set_upstream_gone(
-                              r, buf, ug->gone);
+                    u.buf = ngx_http_vhost_traffic_status_display_set_upstream_gone(
+                                r, u.buf, ug->gone);
                 }
             }
 
-            if (s == buf) {
-                buf = o;
+            if (s == u.buf) {
+                u.buf = o;
 
             } else {
-                buf--;
-                buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_E);
-                buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+                u.buf--;
+                u.buf = ngx_sprintf(u.buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_E);
+                u.buf = ngx_sprintf(u.buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
             }
         }
     }
 
     /* alones */
-    o = buf;
+    o = u.buf;
 
     ngx_str_set(&key, "::nogroups");
 
-    buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_S, &key);
+    u.buf = ngx_sprintf(u.buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_S, &key);
 
-    s = buf;
+    s = u.buf;
 
-    buf = ngx_http_vhost_traffic_status_display_set_upstream_alone(r, buf, ctx->rbtree->root);
+    u.buf = ngx_http_vhost_traffic_status_display_set_upstream_alone(r, u.buf,
+                u.ctx->rbtree->root);
 
-    if (s == buf) {
-        buf = o;
+    if (s == u.buf) {
+        u.buf = o;
 
     } else {
-        buf--;
-        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_E);
-        buf = ngx_sprintf(buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
+        u.buf--;
+        u.buf = ngx_sprintf(u.buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_ARRAY_E);
+        u.buf = ngx_sprintf(u.buf, NGX_HTTP_VHOST_TRAFFIC_STATUS_JSON_FMT_NEXT);
     }
 
-    return buf;
+    return u.buf;
 }
 
 
@@ -1158,89 +1071,68 @@ ngx_http_vhost_traffic_status_display_upstream_groups(ngx_http_request_t *r)
 
 
 /*
+ * Keeps the name of one peer, copied so that the array outlives the walk: a
+ * name held in the zone of the upstream can be given back to the slab by a
+ * re-resolve as soon as the walk releases the lock.
+ */
+
+static ngx_int_t
+ngx_http_vhost_traffic_status_display_keep_upstream_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *uscf, ngx_str_t *name,
+    ngx_http_upstream_server_t *usn, void *data)
+{
+    u_char       *p;
+    ngx_str_t    *n;
+    ngx_array_t  *names = data;
+
+    n = ngx_array_push(names);
+    if (n == NULL) {
+        return NGX_ERROR;
+    }
+
+    n->len = name->len;
+    n->data = NULL;
+
+    /*
+     * The placeholder a `resolve` line leaves behind has no name at all, and
+     * ngx_memcpy() is not to be handed its NULL even for nothing.
+     */
+
+    if (name->len) {
+        p = ngx_pnalloc(r->pool, name->len);
+        if (p == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_memcpy(p, name->data, name->len);
+
+        n->data = p;
+    }
+
+    return NGX_OK;
+}
+
+
+/*
  * Returns the names of the peers that belong to the upstream group now, from
- * the same place the group is written out of: the peer lists where there is a
- * zone, backups included, and the server lines where there is not.
+ * the same walk the group is written out of.
  */
 static ngx_array_t *
 ngx_http_vhost_traffic_status_display_upstream_peer_names(ngx_http_request_t *r,
     ngx_http_upstream_srv_conf_t *uscf)
 {
-    ngx_str_t                    *name;
-    ngx_uint_t                    i, j;
-    ngx_array_t                  *names;
-    ngx_http_upstream_server_t   *us;
-#if (NGX_HTTP_UPSTREAM_ZONE)
-    u_char                       *p;
-    ngx_http_upstream_rr_peer_t  *peer;
-    ngx_http_upstream_rr_peers_t *peers;
-#endif
+    ngx_array_t  *names;
 
     names = ngx_array_create(r->pool, 4, sizeof(ngx_str_t));
     if (names == NULL) {
         return NULL;
     }
 
-#if (NGX_HTTP_UPSTREAM_ZONE)
-
-    if (uscf->shm_zone != NULL) {
-
-        for (peers = uscf->peer.data; peers; peers = peers->next) {
-
-            ngx_http_upstream_rr_peers_rlock(peers);
-
-            for (peer = peers->peer; peer; peer = peer->next) {
-
-                name = ngx_array_push(names);
-                if (name == NULL) {
-                    ngx_http_upstream_rr_peers_unlock(peers);
-                    return NULL;
-                }
-
-                /*
-                 * The names are copied because the peers themselves may be
-                 * replaced by a re-resolve as soon as the lock is released.
-                 */
-
-                p = ngx_pnalloc(r->pool, peer->name.len);
-                if (p == NULL) {
-                    ngx_http_upstream_rr_peers_unlock(peers);
-                    return NULL;
-                }
-
-                ngx_memcpy(p, peer->name.data, peer->name.len);
-
-                name->data = p;
-                name->len = peer->name.len;
-            }
-
-            ngx_http_upstream_rr_peers_unlock(peers);
-        }
-
-        return names;
-    }
-
-#endif
-
-    /* the server lines, which is what is written when there is no zone */
-
-    us = uscf->servers->elts;
-
-    for (i = 0; i < uscf->servers->nelts; i++) {
-
-        /* a server gives one peer per address its name resolves to */
-
-        for (j = 0; j < us[i].naddrs; j++) {
-
-            name = ngx_array_push(names);
-            if (name == NULL) {
-                return NULL;
-            }
-
-            /* these are in the configuration pool and outlive the request */
-
-            *name = us[i].addrs[j].name;
-        }
+    if (ngx_http_vhost_traffic_status_upstream_peers_walk(r, uscf,
+            ngx_http_vhost_traffic_status_display_keep_upstream_peer, names)
+        != NGX_OK)
+    {
+        return NULL;
     }
 
     return names;

--- a/src/ngx_http_vhost_traffic_status_upstream.c
+++ b/src/ngx_http_vhost_traffic_status_upstream.c
@@ -1,0 +1,129 @@
+
+/*
+ * Copyright (C) YoungJoo Kim (vozlt)
+ */
+
+
+#include "ngx_http_vhost_traffic_status_module.h"
+#include "ngx_http_vhost_traffic_status_upstream.h"
+
+#if (NGX_HTTP_UPSTREAM_CHECK)
+#include "ngx_http_upstream_check_module.h"
+#endif
+
+
+/*
+ * Where the peers of an upstream group are, and what the module says about
+ * each of them. Everything that reads a group - the display, the buffer it is
+ * sized into, the peers a group no longer holds, and the control interface -
+ * reads it through here, so that the answers cannot disagree.
+ *
+ * There are two sources and they are exclusive rather than one falling back to
+ * the other. A group with a zone is read from its peer lists, which hold the
+ * peers made at run time as well as the ones the configuration names, and the
+ * backups are a list of their own hanging off peers->next. A group without a
+ * zone is read from its server lines. Reading the lines of a group that has a
+ * zone would answer for the placeholder a `resolve` line leaves behind, whose
+ * name is never set, and miss the peer that took its place.
+ *
+ * Which list a peer was found in is what says whether it is a backup: a name
+ * resolved at run time is not written down anywhere else.
+ */
+
+ngx_int_t
+ngx_http_vhost_traffic_status_upstream_peers_walk(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *uscf,
+    ngx_http_vhost_traffic_status_upstream_peer_pt handler, void *data)
+{
+    ngx_int_t                     rc;
+    ngx_str_t                     name;
+    ngx_uint_t                    i, j;
+    ngx_http_upstream_server_t   *us, usn;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_uint_t                    backup;
+    ngx_http_upstream_rr_peer_t  *peer;
+    ngx_http_upstream_rr_peers_t *peers;
+
+    if (uscf->shm_zone != NULL) {
+
+        for (backup = 0, peers = uscf->peer.data;
+             peers;
+             peers = peers->next, backup = 1)
+        {
+            ngx_http_upstream_rr_peers_rlock(peers);
+
+            for (peer = peers->peer; peer; peer = peer->next) {
+
+                ngx_memzero(&usn, sizeof(ngx_http_upstream_server_t));
+
+                usn.weight = peer->weight;
+                usn.max_fails = peer->max_fails;
+                usn.fail_timeout = peer->fail_timeout;
+                usn.backup = backup;
+
+#if (NGX_HTTP_UPSTREAM_CHECK)
+                usn.down = ngx_http_upstream_check_peer_down(peer->check_index)
+                           ? 1 : 0;
+#else
+
+                /*
+                 * max_fails 0 turns the counting off, which nginx reads as
+                 * never taking the peer out; without the guard the comparison
+                 * holds from the first request and every such peer is called
+                 * down
+                 */
+
+                usn.down = (peer->down
+                            || (peer->max_fails
+                                && peer->fails >= peer->max_fails));
+#endif
+
+                name = peer->name;
+
+#if nginx_version > 1007001
+                usn.name = name;
+#endif
+
+                rc = handler(r, uscf, &name, &usn, data);
+
+                if (rc != NGX_OK) {
+                    ngx_http_upstream_rr_peers_unlock(peers);
+                    return rc;
+                }
+            }
+
+            ngx_http_upstream_rr_peers_unlock(peers);
+        }
+
+        return NGX_OK;
+    }
+
+#endif
+
+    us = uscf->servers->elts;
+
+    for (i = 0; i < uscf->servers->nelts; i++) {
+
+        /* a server gives one peer per address its name resolves to */
+
+        for (j = 0; j < us[i].naddrs; j++) {
+
+            usn = us[i];
+            name = us[i].addrs[j].name;
+
+#if nginx_version > 1007001
+            usn.name = name;
+#endif
+
+            rc = handler(r, uscf, &name, &usn, data);
+
+            if (rc != NGX_OK) {
+                return rc;
+            }
+        }
+    }
+
+    return NGX_OK;
+}
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_vhost_traffic_status_upstream.h
+++ b/src/ngx_http_vhost_traffic_status_upstream.h
@@ -1,0 +1,34 @@
+
+/*
+ * Copyright (C) YoungJoo Kim (vozlt)
+ */
+
+
+#ifndef _NGX_HTTP_VTS_UPSTREAM_H_INCLUDED_
+#define _NGX_HTTP_VTS_UPSTREAM_H_INCLUDED_
+
+
+/*
+ * Called once for each peer the upstream group holds, with the name of the
+ * peer and the attributes the module reports for it. Returning NGX_OK asks
+ * for the next peer; anything else ends the walk, and the walk returns what
+ * the handler returned.
+ *
+ * `name` and `usn` are only good for the length of the call. Where the group
+ * has a zone the name is the one held there, and the walk holds the lock of
+ * the peer list around the handler, so a handler that keeps the name past its
+ * own return has to take a copy of it - a re-resolve gives the peer back to
+ * the slab of the upstream as soon as the lock is released.
+ */
+typedef ngx_int_t (*ngx_http_vhost_traffic_status_upstream_peer_pt)(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf,
+    ngx_str_t *name, ngx_http_upstream_server_t *usn, void *data);
+
+ngx_int_t ngx_http_vhost_traffic_status_upstream_peers_walk(
+    ngx_http_request_t *r, ngx_http_upstream_srv_conf_t *uscf,
+    ngx_http_vhost_traffic_status_upstream_peer_pt handler, void *data);
+
+
+#endif /* _NGX_HTTP_VTS_UPSTREAM_H_INCLUDED_ */
+
+/* vi:set ft=c ts=4 sw=4 et fdm=marker: */


### PR DESCRIPTION
Where the peers of an upstream group are was written out four times:

| | |
| --- | --- |
| `display_set_upstream_group()` | writes them |
| `display_get_upstream_nelts()` | sizes the buffer for them |
| `display_upstream_peer_names()` | collects them to find the ones the group no longer holds |
| `control_peer_lookup()` / `control_server_lookup()` | reads their attributes for the control interface |

Each carried the same rule: the peer lists where the group has a zone,
backups on `peers->next` included, and the server lines where it has not —
exclusively, not as a fallback, because reading the lines of a group that
has a zone answers for the placeholder a `resolve` line leaves behind and
misses the peer that took its place.

**That rule has changed three times, and each change had to find all four
copies.** #381 existed because control disagreed with the display.
#384 changed the display and control and missed the counter, so a group of
101 peers was written as 81 — valid JSON with peers silently dropped.
#385 missed the same rule in the gate on the collection.

The walk now lives in `ngx_http_vhost_traffic_status_upstream.c` and the
four are handlers on it, so a change to the rule cannot reach some of them
and not the others.

### What is not meant to change

No output. Three differences that are not output:

- peer names taken from server lines are now copied like the ones taken from
  a zone — one pool allocation per peer on a display request for a group
  with no zone — so the lifetime of that array is the same whichever source
  it came from
- the placeholder a `resolve` line leaves has no name, and is no longer
  handed to `ngx_memcpy()` as a NULL
- the attribute struct control fills is zeroed first, where the fields
  nobody reads used to hold whatever the caller had left there

### Checked

Built with `-Werror` against nginx 1.30.4 as CI configures it, with
`--without-http-cache`, and with `--without-http_upstream_zone_module`,
which CI does not have. The suite gives the same verdict for every file as
master does.

**There is no red commit to show**, since the change is meant to be
unobservable and no new test could tell it from master. The evidence is
mutation instead — three mutations of the shared walk, each caught by the
suite as it stands:

| mutation | caught by |
| --- | --- |
| do not follow `peers->next` | `t/040`, `t/041` |
| read the server lines despite a zone | `t/028`, `t/040` |
| drop the `max_fails == 0` guard on `down` | `t/038` |

A note on running those: freenginx has no `resolve` server parameter, so
`t/028`, `t/038`, `t/040` and `t/041` report **skipped** there, which
`prove` counts as success. All three mutations came back green against
freenginx before the same runs against nginx 1.30.4 caught them.

### Found but not changed

`node_upstream_lookup()` decides what counts as a group differently from the
other three sites: it skips a `uscf` on `servers == NULL && port != 0`,
where the others take one on `servers && !port`. For a `uscf` with neither
servers nor a port, control would reach `uscf->servers->elts` and read
through NULL. I could not build a configuration that produces one, and
unifying the predicate would change behaviour rather than preserve it, so
each caller keeps its own test here. Happy to raise it separately if it is
worth an issue.
