### PR TITLE
refactor: one table for the names a node member is asked for by

### DIFF
--- a/src/ngx_http_vhost_traffic_status_node.c
+++ b/src/ngx_http_vhost_traffic_status_node.c
@@ -859,79 +859,171 @@ ngx_http_vhost_traffic_status_node_member_cmp(ngx_str_t *member, const char *nam
 }
 
 
+/* the whole of what a node member is called, see node.h */
+
+#define ngx_vts_member(f)  offsetof(ngx_http_vhost_traffic_status_node_t, f)
+
+ngx_http_vhost_traffic_status_member_t
+    ngx_http_vhost_traffic_status_members[] = {
+
+    { ngx_string("request"), ngx_string("requestCounter"),
+      ngx_string("vts_request_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_request_counter) },
+
+    { ngx_string("in"), ngx_string("inBytes"), ngx_string("vts_in_bytes"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_in_bytes) },
+
+    { ngx_string("out"), ngx_string("outBytes"), ngx_string("vts_out_bytes"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_out_bytes) },
+
+    { ngx_string("1xx"), ngx_string("1xx"), ngx_string("vts_1xx_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_1xx_counter) },
+
+    { ngx_string("2xx"), ngx_string("2xx"), ngx_string("vts_2xx_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_2xx_counter) },
+
+    { ngx_string("3xx"), ngx_string("3xx"), ngx_string("vts_3xx_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_3xx_counter) },
+
+    { ngx_string("4xx"), ngx_string("4xx"), ngx_string("vts_4xx_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_4xx_counter) },
+
+    { ngx_string("5xx"), ngx_string("5xx"), ngx_string("vts_5xx_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_5xx_counter) },
+
+    { ngx_null_string, ngx_string("requestMsecCounter"),
+      ngx_string("vts_request_time_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_request_time_counter) },
+
+    { ngx_null_string, ngx_string("requestMsec"),
+      ngx_string("vts_request_time"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_QUEUE,
+      ngx_vts_member(stat_request_times) },
+
+    { ngx_null_string, ngx_string("responseMsecCounter"), ngx_null_string,
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_upstream.response_time_counter) },
+
+    { ngx_null_string, ngx_string("responseMsec"), ngx_null_string,
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_QUEUE,
+      ngx_vts_member(stat_upstream.response_times) },
+
+#if (NGX_HTTP_CACHE)
+
+    { ngx_null_string, ngx_string("cacheMaxSize"), ngx_null_string,
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_max_size) },
+
+    { ngx_null_string, ngx_string("cacheUsedSize"), ngx_null_string,
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_used_size) },
+
+    { ngx_string("cache_miss"), ngx_string("cacheMiss"),
+      ngx_string("vts_cache_miss_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_miss_counter) },
+
+    { ngx_string("cache_bypass"), ngx_string("cacheBypass"),
+      ngx_string("vts_cache_bypass_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_bypass_counter) },
+
+    { ngx_string("cache_expired"), ngx_string("cacheExpired"),
+      ngx_string("vts_cache_expired_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_expired_counter) },
+
+    { ngx_string("cache_stale"), ngx_string("cacheStale"),
+      ngx_string("vts_cache_stale_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_stale_counter) },
+
+    { ngx_string("cache_updating"), ngx_string("cacheUpdating"),
+      ngx_string("vts_cache_updating_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_updating_counter) },
+
+    { ngx_string("cache_revalidated"), ngx_string("cacheRevalidated"),
+      ngx_string("vts_cache_revalidated_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_revalidated_counter) },
+
+    { ngx_string("cache_hit"), ngx_string("cacheHit"),
+      ngx_string("vts_cache_hit_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_hit_counter) },
+
+    { ngx_string("cache_scarce"), ngx_string("cacheScarce"),
+      ngx_string("vts_cache_scarce_counter"),
+      NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER,
+      ngx_vts_member(stat_cache_scarce_counter) },
+
+#endif
+
+    { ngx_null_string, ngx_null_string, ngx_null_string, 0, 0 }
+};
+
+
+ngx_http_vhost_traffic_status_member_t *
+ngx_http_vhost_traffic_status_member_lookup(ngx_str_t *name,
+    ngx_uint_t vocabulary)
+{
+    ngx_str_t                               *n;
+    ngx_http_vhost_traffic_status_member_t  *m;
+
+    for (m = ngx_http_vhost_traffic_status_members;
+         m->limit.len || m->filter.len || m->variable.len;
+         m++)
+    {
+        n = (vocabulary == NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_LIMIT)
+            ? &m->limit : &m->filter;
+
+        /* a field this way in cannot ask for */
+
+        if (n->len == 0) {
+            continue;
+        }
+
+        if (n->len == name->len
+            && ngx_strncmp(n->data, name->data, name->len) == 0)
+        {
+            return m;
+        }
+    }
+
+    return NULL;
+}
+
+
 ngx_atomic_uint_t
 ngx_http_vhost_traffic_status_node_member(ngx_http_vhost_traffic_status_node_t *vtsn,
     ngx_str_t *member)
 {
-    if (ngx_http_vhost_traffic_status_node_member_cmp(member, "request") == 0)
-    {
-        return vtsn->stat_request_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "in") == 0)
-    {
-        return vtsn->stat_in_bytes;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "out") == 0)
-    {
-        return vtsn->stat_out_bytes;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "1xx") == 0)
-    {
-        return vtsn->stat_1xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "2xx") == 0)
-    {
-        return vtsn->stat_2xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "3xx") == 0)
-    {
-        return vtsn->stat_3xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "4xx") == 0)
-    {
-        return vtsn->stat_4xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "5xx") == 0)
-    {
-        return vtsn->stat_5xx_counter;
+    ngx_http_vhost_traffic_status_member_t  *m;
+
+    m = ngx_http_vhost_traffic_status_member_lookup(member,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_LIMIT);
+
+    /*
+     * A name the limit cannot be given reads 0, which is what it read before
+     * this was a table. It is the same answer an untouched counter gives, so
+     * a limit named after nothing is never reached rather than always.
+     */
+
+    if (m == NULL || m->kind != NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER) {
+        return 0;
     }
 
-#if (NGX_HTTP_CACHE)
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_miss") == 0)
-    {
-        return vtsn->stat_cache_miss_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_bypass") == 0)
-    {
-        return vtsn->stat_cache_bypass_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_expired") == 0)
-    {
-        return vtsn->stat_cache_expired_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_stale") == 0)
-    {
-        return vtsn->stat_cache_stale_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_updating") == 0)
-    {
-        return vtsn->stat_cache_updating_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_revalidated") == 0)
-    {
-        return vtsn->stat_cache_revalidated_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_hit") == 0)
-    {
-        return vtsn->stat_cache_hit_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cache_scarce") == 0)
-    {
-        return vtsn->stat_cache_scarce_counter;
-    }
-#endif
-
-    return 0;
+    return *((ngx_atomic_t *) ((char *) vtsn + m->offset));
 }
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_vhost_traffic_status_node.h
+++ b/src/ngx_http_vhost_traffic_status_node.h
@@ -231,6 +231,48 @@ ngx_atomic_uint_t ngx_http_vhost_traffic_status_node_member(
     ngx_str_t *member);
 
 
+/*
+ * One field of a node is asked for by three different names, one per way in
+ * of asking, and the three used to be written out separately - a ladder in
+ * node.c for the limit, a ladder in set.c for set_by_filter, and a table in
+ * variables.c. Sixteen fields appear in all three, so adding a counter meant
+ * finding three places, and a name could be dropped from one of them without
+ * anything else noticing.
+ *
+ * The names are here instead, beside the offset they all mean. An empty name
+ * is a field that way in cannot ask for.
+ *
+ * `variable` carries the whole public name rather than what follows vts_, so
+ * that every string in this table is one a configuration can be grepped for.
+ *
+ * The peers of an upstream group are not here: weight, maxFails, failTimeout,
+ * backup and down are fields of ngx_http_upstream_server_t rather than of a
+ * node, and `backup` is a bit field, which has no offset to take. set.c reads
+ * those five itself.
+ */
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_COUNTER  0
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_QUEUE    1
+
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_LIMIT    0
+#define NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_FILTER   1
+
+typedef struct {
+    ngx_str_t   limit;      /* vhost_traffic_status_limit_traffic */
+    ngx_str_t   filter;     /* vhost_traffic_status_set_by_filter */
+    ngx_str_t   variable;   /* the $vts_ variable, whole */
+    ngx_uint_t  kind;
+    size_t      offset;     /* into ngx_http_vhost_traffic_status_node_t */
+} ngx_http_vhost_traffic_status_member_t;
+
+extern ngx_http_vhost_traffic_status_member_t
+    ngx_http_vhost_traffic_status_members[];
+
+ngx_http_vhost_traffic_status_member_t *
+    ngx_http_vhost_traffic_status_member_lookup(ngx_str_t *name,
+    ngx_uint_t vocabulary);
+
+
 #endif /* _NGX_HTTP_VTS_NODE_H_INCLUDED_ */
 
 /* vi:set ft=c ts=4 sw=4 et fdm=marker: */

--- a/src/ngx_http_vhost_traffic_status_set.c
+++ b/src/ngx_http_vhost_traffic_status_set.c
@@ -82,109 +82,43 @@ ngx_http_vhost_traffic_status_set_by_filter_node_member(
     ngx_http_upstream_server_t *us)
 {
     ngx_str_t                                 *member;
+    ngx_http_vhost_traffic_status_member_t    *m;
     ngx_http_vhost_traffic_status_loc_conf_t  *vtscf;
 
     member = control->arg_name;
     vtscf = ngx_http_get_module_loc_conf(control->r,
                                          ngx_http_vhost_traffic_status_module);
 
-    if (ngx_http_vhost_traffic_status_node_member_cmp(member, "requestCounter") == 0)
-    {
-        return vtsn->stat_request_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "requestMsecCounter") == 0)
-    {
-        return vtsn->stat_request_time_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "requestMsec") == 0)
-    {
-        return (ngx_atomic_uint_t)
-                   ngx_http_vhost_traffic_status_node_time_queue_average_ro(
-                       &vtsn->stat_request_times, vtscf->average_method,
-                       vtscf->average_period);
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "responseMsecCounter") == 0)
-    {
-        return vtsn->stat_upstream.response_time_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "responseMsec") == 0)
-    {
-        return (ngx_atomic_uint_t)
-                   ngx_http_vhost_traffic_status_node_time_queue_average_ro(
-                       &vtsn->stat_upstream.response_times, vtscf->average_method,
-                       vtscf->average_period);
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "inBytes") == 0)
-    {
-        return vtsn->stat_in_bytes;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "outBytes") == 0)
-    {
-        return vtsn->stat_out_bytes;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "1xx") == 0)
-    {
-        return vtsn->stat_1xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "2xx") == 0)
-    {
-        return vtsn->stat_2xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "3xx") == 0)
-    {
-        return vtsn->stat_3xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "4xx") == 0)
-    {
-        return vtsn->stat_4xx_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "5xx") == 0)
-    {
-        return vtsn->stat_5xx_counter;
+    /* the fields of the node, named the same way in one table (node.h) */
+
+    m = ngx_http_vhost_traffic_status_member_lookup(member,
+            NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_FILTER);
+
+    if (m != NULL) {
+
+        if (m->kind == NGX_HTTP_VHOST_TRAFFIC_STATUS_MEMBER_QUEUE) {
+
+            /*
+             * the read-only average, as this runs while the display may be
+             * reading the same queue
+             */
+
+            return (ngx_atomic_uint_t)
+                       ngx_http_vhost_traffic_status_node_time_queue_average_ro(
+                           (ngx_http_vhost_traffic_status_node_time_queue_t *)
+                               ((char *) vtsn + m->offset),
+                           vtscf->average_method, vtscf->average_period);
+        }
+
+        return *((ngx_atomic_t *) ((char *) vtsn + m->offset));
     }
 
-#if (NGX_HTTP_CACHE)
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheMaxSize") == 0)
-    {
-        return vtsn->stat_cache_max_size;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheUsedSize") == 0)
-    {
-        return vtsn->stat_cache_used_size;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheMiss") == 0)
-    {
-        return vtsn->stat_cache_miss_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheBypass") == 0)
-    {
-        return vtsn->stat_cache_bypass_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheExpired") == 0)
-    {
-        return vtsn->stat_cache_expired_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheStale") == 0)
-    {
-        return vtsn->stat_cache_stale_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheUpdating") == 0)
-    {
-        return vtsn->stat_cache_updating_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheRevalidated") == 0)
-    {
-        return vtsn->stat_cache_revalidated_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheHit") == 0)
-    {
-        return vtsn->stat_cache_hit_counter;
-    }
-    else if (ngx_http_vhost_traffic_status_node_member_cmp(member, "cacheScarce") == 0)
-    {
-        return vtsn->stat_cache_scarce_counter;
-    }
-#endif
+    /*
+     * What is left belongs to the peer rather than to the node, and is only
+     * there to be asked for when the zone names one: these are fields of
+     * ngx_http_upstream_server_t, and `backup` is a bit field, so they cannot
+     * be reached through an offset the way the table reaches a node.
+     */
 
     switch (control->group) {
 

--- a/src/ngx_http_vhost_traffic_status_variables.c
+++ b/src/ngx_http_vhost_traffic_status_variables.c
@@ -8,105 +8,6 @@
 #include "ngx_http_vhost_traffic_status_variables.h"
 
 
-static ngx_http_variable_t  ngx_http_vhost_traffic_status_vars[] = {
-
-    { ngx_string("vts_request_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_in_bytes"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_in_bytes),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_out_bytes"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_out_bytes),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_1xx_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_1xx_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_2xx_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_2xx_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_3xx_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_3xx_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_4xx_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_4xx_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_5xx_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_5xx_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_request_time_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_time_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    /* the offset names the queue this averages, it is not read through */
-    { ngx_string("vts_request_time"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_request_times),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-#if (NGX_HTTP_CACHE)
-    { ngx_string("vts_cache_miss_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_miss_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_bypass_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_bypass_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_expired_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_expired_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_stale_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_stale_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_updating_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_updating_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_revalidated_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_revalidated_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_hit_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_hit_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-
-    { ngx_string("vts_cache_scarce_counter"), NULL,
-      ngx_http_vhost_traffic_status_node_variable,
-      offsetof(ngx_http_vhost_traffic_status_node_t, stat_cache_scarce_counter),
-      NGX_HTTP_VAR_NOCACHEABLE, 0 },
-#endif
-
-    { ngx_null_string, NULL, NULL, 0, 0, 0 }
-};
-
-
 ngx_int_t
 ngx_http_vhost_traffic_status_node_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data)
@@ -186,19 +87,37 @@ done:
 }
 
 
+/*
+ * The variables are the members of a node that carry a `variable` name in the
+ * table in node.h, which is also where the offset each of them reads comes
+ * from. They used to be a list of their own, so a field could be given a
+ * variable here and a set_by_filter name there without the two ever meeting.
+ */
+
 ngx_int_t
 ngx_http_vhost_traffic_status_add_variables(ngx_conf_t *cf)
 {
-    ngx_http_variable_t  *var, *v;
+    ngx_http_variable_t                     *var;
+    ngx_http_vhost_traffic_status_member_t  *m;
 
-    for (v = ngx_http_vhost_traffic_status_vars; v->name.len; v++) {
-        var = ngx_http_add_variable(cf, &v->name, v->flags);
+    for (m = ngx_http_vhost_traffic_status_members;
+         m->limit.len || m->filter.len || m->variable.len;
+         m++)
+    {
+        /* a field with no variable to read it by */
+
+        if (m->variable.len == 0) {
+            continue;
+        }
+
+        var = ngx_http_add_variable(cf, &m->variable,
+                                    NGX_HTTP_VAR_NOCACHEABLE);
         if (var == NULL) {
             return NGX_ERROR;
         }
 
-        var->get_handler = v->get_handler;
-        var->data = v->data;
+        var->get_handler = ngx_http_vhost_traffic_status_node_variable;
+        var->data = (uintptr_t) m->offset;
     }
 
     return NGX_OK;

--- a/t/046.member_names.t
+++ b/t/046.member_names.t
@@ -1,0 +1,201 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The names a member of a node can be asked for by. There are three
+# vocabularies over one set of fields, and each of them is written out
+# separately:
+#
+#   $vts_request_counter    the variables       (variables.c)
+#   requestCounter          set_by_filter       (set.c)
+#   request                 limit_traffic       (node.c, node_member)
+#
+# The suite reached 7 of the 18 variables, 7 of the 27 set_by_filter members
+# and 3 of the 16 limit members, so most of these names could be dropped or
+# misspelled without anything going red. This file names all of them that a
+# build with no cache can name; the cache ones are in t/047.
+#
+# What each kind of assertion is worth:
+#
+#   variables      total. An unknown $vts_ name is a configuration error, so
+#                  a dropped name stops nginx from starting and the whole
+#                  file fails
+#   set_by_filter  partial. An unknown member reads 0, which is also what an
+#                  untouched counter reads, so only the members that can be
+#                  made non-zero here are told apart from a dropped name
+#   limit          partial, and for the same reason: an unknown member never
+#                  reaches its limit, which is what an unused one does too
+#
+# set_by_filter and limit_traffic are ACCESS phase handlers, so a location
+# that answers with `return` never reaches them. The locations that read a
+# member serve a file instead.
+
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * 29;
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: every variable of a build with no cache is a known name
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /v {
+        add_header X-Request-Counter    $vts_request_counter;
+        add_header X-In-Bytes           $vts_in_bytes;
+        add_header X-Out-Bytes          $vts_out_bytes;
+        add_header X-1xx                $vts_1xx_counter;
+        add_header X-2xx                $vts_2xx_counter;
+        add_header X-3xx                $vts_3xx_counter;
+        add_header X-4xx                $vts_4xx_counter;
+        add_header X-5xx                $vts_5xx_counter;
+        add_header X-Request-Time-Ctr   $vts_request_time_counter;
+        add_header X-Request-Time       $vts_request_time;
+        return 200 "OK";
+    }
+--- request eval
+['GET /v', 'GET /v']
+--- response_body_like eval
+['OK', 'OK']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Request-Counter)/s,
+    qr/X-Request-Counter: 1\b.*X-In-Bytes: [1-9]\d*.*X-Out-Bytes: [1-9]\d*.*X-1xx: 0\b.*X-2xx: 1\b.*X-3xx: 0\b.*X-4xx: 0\b.*X-5xx: 0\b.*X-Request-Time-Ctr: \d+\b.*X-Request-Time: \d+\b/s,
+]
+
+=== TEST 2: the set_by_filter members of a server zone
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /v {
+        return 200 "OK";
+    }
+
+    location /three {
+        return 301 "/v";
+    }
+
+    location /five {
+        return 500 "no";
+    }
+
+    location /m.txt {
+        vhost_traffic_status_set_by_filter $requestCounter     server/localhost/requestCounter;
+        vhost_traffic_status_set_by_filter $requestMsecCounter server/localhost/requestMsecCounter;
+        vhost_traffic_status_set_by_filter $requestMsec        server/localhost/requestMsec;
+        vhost_traffic_status_set_by_filter $inBytes            server/localhost/inBytes;
+        vhost_traffic_status_set_by_filter $outBytes           server/localhost/outBytes;
+        vhost_traffic_status_set_by_filter $c1xx               server/localhost/1xx;
+        vhost_traffic_status_set_by_filter $c2xx               server/localhost/2xx;
+        vhost_traffic_status_set_by_filter $c3xx               server/localhost/3xx;
+        vhost_traffic_status_set_by_filter $c4xx               server/localhost/4xx;
+        vhost_traffic_status_set_by_filter $c5xx               server/localhost/5xx;
+
+        add_header X-Request-Counter  $requestCounter;
+        add_header X-Request-Msec-Ctr $requestMsecCounter;
+        add_header X-Request-Msec     $requestMsec;
+        add_header X-In-Bytes         $inBytes;
+        add_header X-Out-Bytes        $outBytes;
+        add_header X-1xx              $c1xx;
+        add_header X-2xx              $c2xx;
+        add_header X-3xx              $c3xx;
+        add_header X-4xx              $c4xx;
+        add_header X-5xx              $c5xx;
+    }
+--- user_files
+>>> m.txt
+read
+--- request eval
+['GET /v', 'GET /three', 'GET /missing', 'GET /five', 'GET /m.txt']
+--- error_code eval
+[200, 301, 404, 500, 200]
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Request-Counter)/s,
+    qr/\A(?!.*X-Request-Counter)/s,
+    qr/\A(?!.*X-Request-Counter)/s,
+    qr/\A(?!.*X-Request-Counter)/s,
+    qr/X-Request-Counter: [1-9]\d*.*X-Request-Msec-Ctr: \d+\b.*X-Request-Msec: \d+\b.*X-In-Bytes: [1-9]\d*.*X-Out-Bytes: [1-9]\d*.*X-1xx: 0\b.*X-2xx: [1-9]\d*.*X-3xx: [1-9]\d*.*X-4xx: [1-9]\d*.*X-5xx: [1-9]\d*/s,
+]
+
+=== TEST 3: the members an upstream peer answers for, which a server zone has no value for
+--- http_config
+    vhost_traffic_status_zone;
+
+    upstream backend {
+        server 127.0.0.1:1984 weight=5 max_fails=3 fail_timeout=20s;
+    }
+
+    server {
+        listen 1984;
+        location / {
+            return 200 "up";
+        }
+    }
+--- config
+    location /p {
+        proxy_pass http://backend;
+    }
+
+    location /m.txt {
+        vhost_traffic_status_set_by_filter $weight      upstream@group/backend@127.0.0.1:1984/weight;
+        vhost_traffic_status_set_by_filter $maxFails    upstream@group/backend@127.0.0.1:1984/maxFails;
+        vhost_traffic_status_set_by_filter $failTimeout upstream@group/backend@127.0.0.1:1984/failTimeout;
+        vhost_traffic_status_set_by_filter $down        upstream@group/backend@127.0.0.1:1984/down;
+        vhost_traffic_status_set_by_filter $backup      upstream@group/backend@127.0.0.1:1984/backup;
+        vhost_traffic_status_set_by_filter $respCtr     upstream@group/backend@127.0.0.1:1984/responseMsecCounter;
+        vhost_traffic_status_set_by_filter $respMsec    upstream@group/backend@127.0.0.1:1984/responseMsec;
+
+        add_header X-Weight       $weight;
+        add_header X-Max-Fails    $maxFails;
+        add_header X-Fail-Timeout $failTimeout;
+        add_header X-Down         $down;
+        add_header X-Backup       $backup;
+        add_header X-Resp-Ctr     $respCtr;
+        add_header X-Resp-Msec    $respMsec;
+    }
+--- user_files
+>>> m.txt
+read
+--- request eval
+['GET /p', 'GET /m.txt']
+--- response_body_like eval
+['up', 'read']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Weight)/s,
+    qr/X-Weight: 5\b.*X-Max-Fails: 3\b.*X-Fail-Timeout: 20\b.*X-Down: 0\b.*X-Resp-Ctr: \d+\b.*X-Resp-Msec: \d+\b/s,
+]
+
+=== TEST 4: the limit members a request of this shape can reach
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /r.txt {
+        vhost_traffic_status_limit_traffic request:2;
+    }
+
+    location /i.txt {
+        vhost_traffic_status_limit_traffic in:1;
+    }
+
+    location /o.txt {
+        vhost_traffic_status_limit_traffic out:1;
+    }
+
+    location /s.txt {
+        vhost_traffic_status_limit_traffic 2xx:2;
+    }
+--- user_files
+>>> r.txt
+r
+>>> i.txt
+i
+>>> o.txt
+o
+>>> s.txt
+s
+--- request eval
+['GET /r.txt', 'GET /r.txt', 'GET /r.txt', 'GET /r.txt', 'GET /i.txt', 'GET /o.txt', 'GET /s.txt']
+--- error_code eval
+[200, 200, 200, 503, 503, 503, 503]

--- a/t/046.member_names.t
+++ b/t/046.member_names.t
@@ -40,7 +40,7 @@ __DATA__
 --- http_config
     vhost_traffic_status_zone;
 --- config
-    location /v {
+    location /big.txt {
         add_header X-Request-Counter    $vts_request_counter;
         add_header X-In-Bytes           $vts_in_bytes;
         add_header X-Out-Bytes          $vts_out_bytes;
@@ -51,16 +51,17 @@ __DATA__
         add_header X-5xx                $vts_5xx_counter;
         add_header X-Request-Time-Ctr   $vts_request_time_counter;
         add_header X-Request-Time       $vts_request_time;
-        return 200 "OK";
     }
+--- user_files eval
+">>> big.txt\n" . ("x" x 4096)
 --- request eval
-['GET /v', 'GET /v']
+['GET /big.txt', 'GET /big.txt']
 --- response_body_like eval
-['OK', 'OK']
+['x{4096}', 'x{4096}']
 --- raw_response_headers_like eval
 [
     qr/\A(?!.*X-Request-Counter)/s,
-    qr/X-Request-Counter: 1\b.*X-In-Bytes: [1-9]\d*.*X-Out-Bytes: [1-9]\d*.*X-1xx: 0\b.*X-2xx: 1\b.*X-3xx: 0\b.*X-4xx: 0\b.*X-5xx: 0\b.*X-Request-Time-Ctr: \d+\b.*X-Request-Time: \d+\b/s,
+    qr/X-Request-Counter: 1\b.*X-In-Bytes: \d{1,3}\b.*X-Out-Bytes: [1-9]\d{3,}\b.*X-1xx: 0\b.*X-2xx: 1\b.*X-3xx: 0\b.*X-4xx: 0\b.*X-5xx: 0\b.*X-Request-Time-Ctr: \d+\b.*X-Request-Time: \d+\b/s,
 ]
 
 === TEST 2: the set_by_filter members of a server zone

--- a/t/047.member_names_cache.t
+++ b/t/047.member_names_cache.t
@@ -1,0 +1,117 @@
+# vi:set ft=perl ts=4 sw=4 et fdm=marker:
+
+# The half of t/046 that a build without the cache cannot name. The cache
+# members are declared inside #if (NGX_HTTP_CACHE), so naming one of them
+# keeps nginx from starting on such a build - which is why they are here and
+# not in t/046, and why this file steps aside when the cache is not built in.
+#
+# The same three vocabularies, and the same limits on what each assertion is
+# worth. See the head of t/046.
+
+use Test::Nginx::Socket;
+
+my $nginx = $ENV{TEST_NGINX_BINARY} || 'nginx';
+my $configure = `$nginx -V 2>&1` || '';
+
+plan skip_all => "the cache is not built in: $nginx -V says --without-http-cache"
+    if $configure =~ /--without-http-cache/;
+
+plan tests => repeat_each() * 15;
+
+add_cleanup_handler(
+    sub {
+        my $CacheDir = "$Test::Nginx::Util::ServRoot/cache_*";
+        system("rm -rf $CacheDir > /dev/null") == 0 or
+        bail_out "Can't remove $CacheDir";
+    }
+);
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: every cache variable is a known name
+--- http_config
+    vhost_traffic_status_zone;
+--- config
+    location /v {
+        add_header X-Miss        $vts_cache_miss_counter;
+        add_header X-Bypass      $vts_cache_bypass_counter;
+        add_header X-Expired     $vts_cache_expired_counter;
+        add_header X-Stale       $vts_cache_stale_counter;
+        add_header X-Updating    $vts_cache_updating_counter;
+        add_header X-Revalidated $vts_cache_revalidated_counter;
+        add_header X-Hit         $vts_cache_hit_counter;
+        add_header X-Scarce      $vts_cache_scarce_counter;
+        return 200 "OK";
+    }
+--- request eval
+['GET /v', 'GET /v']
+--- response_body_like eval
+['OK', 'OK']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Miss)/s,
+    qr/X-Miss: 0\b.*X-Bypass: 0\b.*X-Expired: 0\b.*X-Stale: 0\b.*X-Updating: 0\b.*X-Revalidated: 0\b.*X-Hit: 0\b.*X-Scarce: 0\b/s,
+]
+
+=== TEST 2: the set_by_filter members of a cache zone, and the cache limit members
+--- http_config
+    vhost_traffic_status_zone;
+    proxy_cache_path cache_one levels=1:2 keys_zone=cache_one:2m inactive=1m max_size=4m;
+
+    upstream backend {
+        server 127.0.0.1:1984;
+    }
+
+    server {
+        listen 1984;
+        location / {
+            add_header Cache-Control "max-age=10";
+            return 200 "up";
+        }
+    }
+--- config
+    location /p {
+        proxy_cache cache_one;
+        proxy_cache_valid 200 10s;
+        proxy_pass http://backend;
+    }
+
+    location /m.txt {
+        vhost_traffic_status_set_by_filter $cacheMaxSize     cache/cache_one/cacheMaxSize;
+        vhost_traffic_status_set_by_filter $cacheUsedSize    cache/cache_one/cacheUsedSize;
+        vhost_traffic_status_set_by_filter $cacheMiss        cache/cache_one/cacheMiss;
+        vhost_traffic_status_set_by_filter $cacheHit         cache/cache_one/cacheHit;
+        vhost_traffic_status_set_by_filter $cacheBypass      cache/cache_one/cacheBypass;
+        vhost_traffic_status_set_by_filter $cacheExpired     cache/cache_one/cacheExpired;
+        vhost_traffic_status_set_by_filter $cacheStale       cache/cache_one/cacheStale;
+        vhost_traffic_status_set_by_filter $cacheUpdating    cache/cache_one/cacheUpdating;
+        vhost_traffic_status_set_by_filter $cacheRevalidated cache/cache_one/cacheRevalidated;
+        vhost_traffic_status_set_by_filter $cacheScarce      cache/cache_one/cacheScarce;
+
+        add_header X-Max-Size    $cacheMaxSize;
+        add_header X-Used-Size   $cacheUsedSize;
+        add_header X-Miss        $cacheMiss;
+        add_header X-Hit         $cacheHit;
+        add_header X-Bypass      $cacheBypass;
+        add_header X-Expired     $cacheExpired;
+        add_header X-Stale       $cacheStale;
+        add_header X-Updating    $cacheUpdating;
+        add_header X-Revalidated $cacheRevalidated;
+        add_header X-Scarce      $cacheScarce;
+    }
+--- user_files
+>>> m.txt
+read
+--- request eval
+['GET /p', 'GET /p', 'GET /m.txt']
+--- response_body_like eval
+['up', 'up', 'read']
+--- raw_response_headers_like eval
+[
+    qr/\A(?!.*X-Max-Size)/s,
+    qr/\A(?!.*X-Max-Size)/s,
+    qr/X-Max-Size: [1-9]\d*.*X-Miss: [1-9]\d*.*X-Hit: [1-9]\d*.*X-Bypass: 0\b.*X-Expired: 0\b.*X-Stale: 0\b.*X-Updating: 0\b.*X-Revalidated: 0\b.*X-Scarce: 0\b/s,
+]

--- a/t/047.member_names_cache.t
+++ b/t/047.member_names_cache.t
@@ -16,7 +16,7 @@ my $configure = `$nginx -V 2>&1` || '';
 plan skip_all => "the cache is not built in: $nginx -V says --without-http-cache"
     if $configure =~ /--without-http-cache/;
 
-plan tests => repeat_each() * 15;
+plan tests => repeat_each() * 21;
 
 add_cleanup_handler(
     sub {
@@ -56,7 +56,44 @@ __DATA__
     qr/X-Miss: 0\b.*X-Bypass: 0\b.*X-Expired: 0\b.*X-Stale: 0\b.*X-Updating: 0\b.*X-Revalidated: 0\b.*X-Hit: 0\b.*X-Scarce: 0\b/s,
 ]
 
-=== TEST 2: the set_by_filter members of a cache zone, and the cache limit members
+=== TEST 2: the cache limit members, which nothing else reaches
+--- http_config
+    vhost_traffic_status_zone;
+    proxy_cache_path /tmp/vts_cache_hit_limit levels=1:2 keys_zone=cache_hit_limit:2m
+                     inactive=1m max_size=4m;
+
+    upstream backend_hit {
+        server 127.0.0.1:1984;
+    }
+
+    server {
+        listen 1984;
+        location / {
+            add_header Cache-Control "max-age=10";
+            return 200 "up";
+        }
+    }
+--- config
+    location /c {
+        proxy_cache cache_hit_limit;
+        proxy_cache_valid 200 10s;
+        proxy_pass http://backend_hit;
+    }
+
+    location /h.txt {
+        vhost_traffic_status_limit_traffic cache_hit:1;
+    }
+--- user_files
+>>> h.txt
+h
+--- post_setup_server_root
+system("rm -rf /tmp/vts_cache_hit_limit");
+--- request eval
+['GET /c', 'GET /h.txt', 'GET /c', 'GET /h.txt', 'GET /c', 'GET /h.txt']
+--- error_code eval
+[200, 200, 200, 200, 200, 503]
+
+=== TEST 3: the set_by_filter members of a cache zone
 --- http_config
     vhost_traffic_status_zone;
     proxy_cache_path cache_one levels=1:2 keys_zone=cache_one:2m inactive=1m max_size=4m;
@@ -115,3 +152,4 @@ read
     qr/\A(?!.*X-Max-Size)/s,
     qr/X-Max-Size: [1-9]\d*.*X-Miss: [1-9]\d*.*X-Hit: [1-9]\d*.*X-Bypass: 0\b.*X-Expired: 0\b.*X-Stale: 0\b.*X-Updating: 0\b.*X-Revalidated: 0\b.*X-Scarce: 0\b/s,
 ]
+


### PR DESCRIPTION
Three ways in ask for the fields of a node, each by its own name:

| | asks by | where the list lived |
| --- | --- | --- |
| `$vts_*` variables | `vts_request_counter` | a table in `variables.c` |
| `set_by_filter` | `requestCounter` | a ladder in `set.c` |
| `limit_traffic` | `request` | a ladder in `node.c` |

**Sixteen fields answer to all three**, so adding a counter meant finding
three places, and a name could be dropped from one of them without anything
else noticing. The names now sit together in one table, beside the offset
they all mean.

An empty name is a field that way in cannot ask for — which is most of what
the table says that three separate lists could not say at all: that
`responseMsec` has no variable, that `requestMsecCounter` cannot limit
anything.

The variables are registered from the same table rather than from a list of
their own, so the table holds the whole public name and a configuration can
be grepped for every string in it.

### What did not move

- the peer attributes of `set_by_filter` — `weight`, `maxFails`,
  `failTimeout`, `backup`, `down` — are fields of
  `ngx_http_upstream_server_t` rather than of a node, and `backup` is a bit
  field, so there is no offset to keep. `set.c` still reads those five
  itself, and `node_member_cmp()` stays for them
- the two averages keep the variants they had, the read-only one for
  `set_by_filter` and the plain one for the variable, which differ in
  whether they may write to the queue

**No name changes.**

### The test comes first, and it is green on master

The suite reached 7 of the 18 variables, 7 of the 27 `set_by_filter` members
and 3 of the 16 limit members, so most of these names could be dropped or
misspelled without anything going red — including by this change. `t/046`
and `t/047` are the commit before the refactor. They pin the names on master
and stay green here.

There is no red commit to show: nothing about this is meant to be
observable, so no test could tell it from master. The evidence is mutation.

| mutation | caught by |
| --- | --- |
| drop the `3xx` row from the table | `t/046` |
| misspell the `cacheHit` name | `t/047` |
| point the `out` row at `stat_in_bytes` | `t/046` |

The third one was **not** caught at first: `[1-9]\d*` cannot tell two
non-zero byte counts apart. `t/046` now serves a 4096 byte response so the
two differ by length.

### What the tests are worth, by vocabulary

The head of `t/046` says this too, since it is not uniform:

- **variables — total.** An unknown `$vts_` name is a configuration error, so
  a dropped name stops nginx from starting
- **set_by_filter and limit — partial.** An unknown member reads 0, which is
  also what an untouched counter reads. Only the members that can be made
  non-zero are told apart from a dropped name. `requestMsec`, `responseMsec`,
  `down` and `backup` are exercised but **not** pinned

Both locations that read a member serve a file rather than answering with
`return`: these are ACCESS phase handlers, and a location that returns never
reaches them.

### Checked

Built with `-Werror` against nginx 1.30.4 as CI configures it, with
`--without-http-cache`, and with `--without-http_upstream_zone_module`,
which CI does not have. The suite gives the same verdict for every file as
master does.
