### PR TITLE
docs: disclose how a contribution was produced, and what to check before opening it

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -55,3 +55,23 @@ body:
       label: Reproducible Example nginx.conf
       description: >	
         Please paste the reproducible nginx.conf
+  - type: dropdown
+    id: assistance-disclosure
+    attributes:
+      label: Assistance Disclosure
+      description: >
+        The use of AI/LLM tools is allowed, so long as it is disclosed. Knowing
+        how this was produced helps us respond to it properly; it does not count
+        against you. Please say whether any such tooling was used here.
+      options:
+        - AI used
+        - AI not used
+    validations:
+      required: true
+  - type: input
+    id: assistance-description
+    attributes:
+      label: If AI was used, describe the extent to which it was used.
+      placeholder: >
+        Examples: "Claude produced the reproduction", "ChatGPT translated this
+        from my native language", "the report is entirely generated"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -40,3 +40,23 @@ body:
       label: Additional Context
       description: >
         Please provide any relevant GitHub issues, code examples or references that help describe and support the feature request.
+  - type: dropdown
+    id: assistance-disclosure
+    attributes:
+      label: Assistance Disclosure
+      description: >
+        The use of AI/LLM tools is allowed, so long as it is disclosed. Knowing
+        how this was produced helps us respond to it properly; it does not count
+        against you. Please say whether any such tooling was used here.
+      options:
+        - AI used
+        - AI not used
+    validations:
+      required: true
+  - type: input
+    id: assistance-description
+    attributes:
+      label: If AI was used, describe the extent to which it was used.
+      placeholder: >
+        Examples: "Claude produced the reproduction", "ChatGPT translated this
+        from my native language", "the report is entirely generated"

--- a/.github/ISSUE_TEMPLATE/submit_question.yaml
+++ b/.github/ISSUE_TEMPLATE/submit_question.yaml
@@ -33,3 +33,23 @@ body:
       label: Reproducible Example nginx.conf
       description: >	
         Please paste the reproducible nginx.conf
+  - type: dropdown
+    id: assistance-disclosure
+    attributes:
+      label: Assistance Disclosure
+      description: >
+        The use of AI/LLM tools is allowed, so long as it is disclosed. Knowing
+        how this was produced helps us respond to it properly; it does not count
+        against you. Please say whether any such tooling was used here.
+      options:
+        - AI used
+        - AI not used
+    validations:
+      required: true
+  - type: input
+    id: assistance-description
+    attributes:
+      label: If AI was used, describe the extent to which it was used.
+      placeholder: >
+        Examples: "Claude produced the reproduction", "ChatGPT translated this
+        from my native language", "the report is entirely generated"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,66 @@
+<!--
+Thank you for contributing.
+
+Fill in the sections below. Delete the checklist items that do not apply to
+your change rather than leaving them unticked.
+-->
+
+## What this changes
+
+<!-- What the change does, and why. Link the issue it fixes, if there is one. -->
+
+## How it was verified
+
+<!--
+Say what you actually ran, not what should pass. For example:
+
+  nginx 1.31.4, default configure: t/021 t/025 t/042 -> PASS, 88 tests
+  nginx 1.31.4, --without-http-cache: build -> PASS
+  nginx 1.30.4, default configure: full suite -> PASS
+
+If you could not build or test it, say so. That is useful to know and is not
+held against you.
+-->
+
+## Checklist
+
+<!-- These are the things that have broken in this module before. -->
+
+- [ ] Builds with `--without-http-cache` as well as with the cache enabled.
+      Code inside `#if (NGX_HTTP_CACHE)` is not compiled in every build.
+- [ ] If it changes `ngx_http_vhost_traffic_status_node_t`, it bumps
+      `NGX_HTTP_VHOST_TRAFFIC_STATUS_DUMP_FORMAT_VERSION` in
+      `src/ngx_http_vhost_traffic_status_dump.h`. The layout is written to the
+      dump file and lives in the shared memory zone, so a change to it also
+      means a restart rather than a reload, which belongs in `CHANGELOG.md`.
+- [ ] If it uses an nginx field or function added in a particular release, it
+      is guarded on `nginx_version`. The module still builds against old nginx.
+- [ ] If it adds a conversion to a `..._FMT_...` macro, the argument list at
+      every `ngx_sprintf()` that uses the macro was counted against it.
+      `ngx_sprintf()` is variadic, so the compiler will not catch a mismatch.
+- [ ] New behaviour has a test under `t/`, and the `plan tests` count was
+      updated.
+- [ ] `README.md` and `CHANGELOG.md` are updated if the change is visible to
+      users.
+
+## Assistance Disclosure
+
+<!--
+The use of AI/LLM tools is allowed, so long as it is disclosed. Knowing how a
+change was produced helps us review it properly; it does not count against the
+contribution.
+
+Please say to what extent such tooling was used. Examples:
+
+  "No AI was used."
+  "I wrote the code, Claude wrote the tests."
+  "I asked ChatGPT for an approach, then implemented it myself."
+  "Copilot completed the code as I typed it."
+  "The patch is entirely generated; I built it and ran the suite."
+
+We expect you to have checked your contribution for correctness either way.
+
+Replace the line below with your disclosure.
+-->
+
+_This PR is missing an assistance disclosure._


### PR DESCRIPTION
## What this changes

Adds a pull request template, which the repository did not have, and adds an
assistance disclosure to the three issue forms.

Contributions increasingly come with a model somewhere in the loop, and how a
change was produced affects the review it needs — a patch someone wrote by hand
and a patch a model generated want different kinds of attention, even when both
are correct. Rather than guess, ask. This follows what
[caddyserver/caddy](https://github.com/caddyserver/caddy) does: a required
dropdown on every issue form, and a disclosure section in the pull request
template with room to say how far the tooling went. Disclosure is explicitly
not held against a contribution; the point is to review it properly.

Since there was no pull request template at all, it also carries a checklist of
the things this module has actually been broken by, rather than generic advice:

- the build with `--without-http-cache`, which #344 broke and #350 added a CI
  job for;
- `NGX_HTTP_VHOST_TRAFFIC_STATUS_DUMP_FORMAT_VERSION`, which a change to
  `ngx_http_vhost_traffic_status_node_t` has to bump, since that layout is both
  written to the dump file and held in the shared memory zone;
- guarding a newly used nginx field on `nginx_version`, so the module still
  builds against older nginx;
- counting the arguments at every `ngx_sprintf()` when a conversion is added to
  a `..._FMT_...` macro. #398 fixed a mismatch of exactly this kind that had
  been in the tree since 2015, because `ngx_sprintf()` is variadic and nothing
  checks it.

`blank_issues_enabled: false` is added so the forms are the way in.

Two deliberate differences from caddy's templates:

- caddy has consolidated to a single issue form. The three forms here ask for
  `nginx -V` output and a reproducing `nginx.conf`, which are worth keeping, so
  they are left as they are and only gain the disclosure.
- caddy puts an empty first entry in the dropdown to force an explicit choice.
  That is omitted here: with no `default`, a `required` dropdown starts
  unselected anyway, and an empty option string is a needless risk of the form
  failing to render.

## How it was verified

The three issue forms and `config.yml` were parsed and checked to confirm the
disclosure is present and required in each:

    bug_report.yaml:       options=["AI used", "AI not used"] required=true default=nil
    feature_request.yaml:  options=["AI used", "AI not used"] required=true default=nil
    submit_question.yaml:  options=["AI used", "AI not used"] required=true default=nil
    config.yml: {"blank_issues_enabled"=>false}

GitHub validates issue forms when they reach the default branch, so the forms
are worth a look on the preview before merging. No code changes, so the build
and the test suite are untouched.

## Checklist

Nothing here touches the module source, so the build, dump format, nginx
version and format macro items do not apply.

- [x] `README.md` and `CHANGELOG.md` are updated if the change is visible to
      users — not applicable; this changes the contribution forms, not the
      module.

## Assistance Disclosure

AI used. I asked Claude to look at caddyserver/caddy's templates and adapt them
for this repository; it drafted the files and checked the YAML, and I reviewed
the result and chose what to keep from caddy and what to leave alone. The
checklist items come from problems found in this repository over the last few
weeks.
